### PR TITLE
E2-1537: add method to clear content

### DIFF
--- a/src/Leanplum.js
+++ b/src/Leanplum.js
@@ -436,4 +436,13 @@ export default class Leanplum {
   static unregisterFromWebPush() {
     return PushManager.unsubscribeUser()
   }
+
+  /**
+   * Clears cached values for messages, variables and test assignments.
+   * Use sparingly as if the app is updated, you'll have to deal with potentially
+   * inconsistent state or user experience.
+   */
+  static clearUserContent() {
+    VarCache.clearUserContent()
+  }
 }

--- a/src/VarCache.js
+++ b/src/VarCache.js
@@ -183,4 +183,13 @@ export default class VarCache {
     })
     return merged
   }
+
+  static clearUserContent() {
+    VarCache.diffs = undefined
+    VarCache.variables = null
+    VarCache.variants = []
+    VarCache.variantDebugInfo = {}
+    VarCache.merged = undefined
+  }
+
 }


### PR DESCRIPTION
When a user logs out of an app, we need to clear any stale content for the previously logged in user. This adds a method to do that

