### PR TITLE
test: refactor and extend tracking tests

### DIFF
--- a/src/ArgsBuilder.ts
+++ b/src/ArgsBuilder.ts
@@ -23,7 +23,7 @@ import Constants from './Constants'
  */
 export default class ArgsBuilder {
   private argString: string
-  private argValues: Object
+  private argValues: { [key: string]: any }
   private _body: string
 
   /**
@@ -94,7 +94,7 @@ export default class ArgsBuilder {
    * Return the argument values.
    * @return {Object} The argument values.
    */
-  buildDict(): Object {
+  buildDict(): { [key: string]: any } {
     return this.argValues
   }
 }

--- a/test/specs/Leanplum.test.ts
+++ b/test/specs/Leanplum.test.ts
@@ -1,10 +1,9 @@
 /*
- *
  *  Copyright 2020 Leanplum Inc. All rights reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *  You may obtain a copy of the License at:
  *
  *      https://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,11 +11,10 @@
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
- *  limitations under the License
- *
+ *  limitations under the License.
  */
-import sinon from 'sinon'
 
+import sinon from 'sinon'
 import {
   startResponse,
   successResponse,
@@ -208,53 +206,6 @@ Object.keys(testModes).forEach((mode) => {
           done()
         })
         Leanplum.setUserAttributes(userId, userAttributes)
-      })
-
-      it('track', (done) => {
-        interceptRequest((request) => {
-          expect(request).not.toBeNull()
-          expect(getAction(request)).toBe('track')
-          request.respond(200, {
-            'Content-Type': 'application/json'
-          }, JSON.stringify(successResponse))
-          done()
-        })
-        Leanplum.track('Page View')
-      })
-
-      it('trackPurchase', (done) => {
-        interceptRequest((request) => {
-          expect(request).not.toBeNull()
-          expect(getAction(request)).toBe('track')
-          const body = JSON.parse(request.requestBody).data[0]
-          const params = JSON.parse(body.params)
-          expect(body.value).toEqual(19.99)
-          expect(params.currencyCode).toEqual('EUR')
-          request.respond(200, {
-            'Content-Type': 'application/json'
-          }, JSON.stringify(successResponse))
-          done()
-        })
-        Leanplum.trackPurchase(19.99, 'EUR')
-      })
-
-      it('trackPurchase with custom event name', (done) => {
-        interceptRequest((request) => {
-          expect(request).not.toBeNull()
-          expect(getAction(request)).toBe('track')
-          const body = JSON.parse(request.requestBody).data[0]
-          const params = JSON.parse(body.params)
-
-          expect(body.event).toEqual('Checkout')
-          expect(body.value).toEqual(19.99)
-          expect(params.itemsInCart).toEqual(4)
-
-          request.respond(200, {
-            'Content-Type': 'application/json'
-          }, JSON.stringify(successResponse))
-          done()
-        })
-        Leanplum.trackPurchase(19.99, 'BGN', { itemsInCart: 4 }, 'Checkout')
       })
 
       it('advanceTo', (done) => {

--- a/test/specs/LeanplumInternal.test.ts
+++ b/test/specs/LeanplumInternal.test.ts
@@ -1,0 +1,182 @@
+/*
+ *  Copyright 2020 Leanplum Inc. All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import Constants from '../../src/Constants'
+import LeanplumInternal from '../../src/LeanplumInternal'
+import LeanplumRequest from '../../src/LeanplumRequest'
+
+const lpRequestMock: Partial<jest.Mocked<LeanplumRequest>> = {
+  request: jest.fn()
+}
+
+const windowMock: Window = {
+  navigator: {
+    userAgent: 'TestAgent'
+  }
+} as Window
+
+jest.mock('../../src/LeanplumRequest', () => {
+  return jest.fn().mockImplementation(() => {
+    return lpRequestMock
+  })
+})
+
+describe(LeanplumInternal, () => {
+  let lp: LeanplumInternal
+
+  beforeEach(() => {
+    lp = new LeanplumInternal(windowMock)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('track', () => {
+    it('works with event name only', () => {
+      lp.track('Foo')
+
+      const [action, args, options] = lpRequestMock.request.mock.calls[0]
+      const {event, value, params, info} = args.buildDict()
+
+      expect(lpRequestMock.request).toHaveBeenCalledTimes(1)
+      expect(action).toEqual(Constants.METHODS.TRACK)
+      expect(event).toEqual('Foo')
+      expect(value).toEqual(0.0)
+      expect(params).toEqual(undefined)
+      expect(info).toEqual(undefined)
+      expect(options).toEqual({ devMode: false, queued: true })
+    })
+
+    it('works with params', () => {
+      lp.track('Foo', { test: true })
+
+      const [action, args, options] = lpRequestMock.request.mock.calls[0]
+      const {event, value, params, info} = args.buildDict()
+
+      expect(lpRequestMock.request).toHaveBeenCalledTimes(1)
+      expect(action).toEqual(Constants.METHODS.TRACK)
+      expect(event).toEqual('Foo')
+      expect(value).toEqual(0.0)
+      expect(params).toEqual(JSON.stringify({ test: true }))
+      expect(info).toEqual(undefined)
+      expect(options).toEqual({ devMode: false, queued: true })
+    })
+
+    it('works with value', () => {
+      lp.track('Foo', 1.23)
+
+      const [action, args, options] = lpRequestMock.request.mock.calls[0]
+      const {event, value, params, info} = args.buildDict()
+
+      expect(lpRequestMock.request).toHaveBeenCalledTimes(1)
+      expect(action).toEqual(Constants.METHODS.TRACK)
+      expect(event).toEqual('Foo')
+      expect(value).toEqual(1.23)
+      expect(params).toEqual(undefined)
+      expect(info).toEqual(undefined)
+      expect(options).toEqual({ devMode: false, queued: true })
+    })
+
+    it('works with value and params', () => {
+      lp.track('Foo', 1.23, { test: true })
+
+      const [action, args, options] = lpRequestMock.request.mock.calls[0]
+      const {event, value, params, info} = args.buildDict()
+
+      expect(lpRequestMock.request).toHaveBeenCalledTimes(1)
+      expect(action).toEqual(Constants.METHODS.TRACK)
+      expect(event).toEqual('Foo')
+      expect(value).toEqual(1.23)
+      expect(params).toEqual(JSON.stringify({ test: true }))
+      expect(info).toEqual(undefined)
+      expect(options).toEqual({ devMode: false, queued: true })
+    })
+
+    it('works with value, info and params', () => {
+      lp.track('Foo', 1.23, 'test', { test: true })
+
+      const [action, args, options] = lpRequestMock.request.mock.calls[0]
+      const {event, value, params, info} = args.buildDict()
+
+      expect(lpRequestMock.request).toHaveBeenCalledTimes(1)
+      expect(action).toEqual(Constants.METHODS.TRACK)
+      expect(event).toEqual('Foo')
+      expect(value).toEqual(1.23)
+      expect(params).toEqual(JSON.stringify({ test: true }))
+      expect(info).toEqual('test')
+      expect(options).toEqual({ devMode: false, queued: true })
+    })
+  })
+
+  describe('trackPurchase', () => {
+    it('works without currency code', () => {
+      lp.trackPurchase(19.99)
+
+      const [action, args, options] = lpRequestMock.request.mock.calls[0]
+      const {event, value, params} = args.buildDict()
+
+      expect(lpRequestMock.request).toHaveBeenCalledTimes(1)
+      expect(action).toEqual(Constants.METHODS.TRACK)
+      expect(event).toEqual('Purchase')
+      expect(value).toEqual(19.99)
+      expect(params).toEqual(undefined)
+      expect(options).toEqual({ devMode: false, queued: true })
+    })
+
+    it('works with currency code', () => {
+      lp.trackPurchase(19.99, 'EUR')
+
+      const [action, args, options] = lpRequestMock.request.mock.calls[0]
+      const {event, value, params} = args.buildDict()
+
+      expect(lpRequestMock.request).toHaveBeenCalledTimes(1)
+      expect(action).toEqual(Constants.METHODS.TRACK)
+      expect(event).toEqual('Purchase')
+      expect(value).toEqual(19.99)
+      expect(params).toEqual(JSON.stringify({ currencyCode: 'EUR' }))
+      expect(options).toEqual({ devMode: false, queued: true })
+    })
+
+    it('works with params', () => {
+      lp.trackPurchase(19.99, 'EUR', { test: true })
+
+      const [action, args, options] = lpRequestMock.request.mock.calls[0]
+      const {event, value, params} = args.buildDict()
+
+      expect(lpRequestMock.request).toHaveBeenCalledTimes(1)
+      expect(action).toEqual(Constants.METHODS.TRACK)
+      expect(event).toEqual('Purchase')
+      expect(value).toEqual(19.99)
+      expect(params).toEqual(JSON.stringify({ test: true, currencyCode: 'EUR' }))
+      expect(options).toEqual({ devMode: false, queued: true })
+    })
+
+    it('works with custom event name', () => {
+      lp.trackPurchase(19.99, 'BGN', { itemsInCart: 4 }, 'Checkout')
+
+      const [action, args, options] = lpRequestMock.request.mock.calls[0]
+      const {event, value, params} = args.buildDict()
+
+      expect(lpRequestMock.request).toHaveBeenCalledTimes(1)
+      expect(action).toEqual(Constants.METHODS.TRACK)
+      expect(event).toEqual('Checkout')
+      expect(value).toEqual(19.99)
+      expect(params).toEqual(JSON.stringify({ itemsInCart: 4, currencyCode: 'BGN' }))
+      expect(options).toEqual({ devMode: false, queued: true })
+    })
+  })
+})

--- a/test/specs/LeanplumInternal.test.ts
+++ b/test/specs/LeanplumInternal.test.ts
@@ -18,6 +18,11 @@ import Constants from '../../src/Constants'
 import LeanplumInternal from '../../src/LeanplumInternal'
 import LeanplumRequest from '../../src/LeanplumRequest'
 
+// Test data
+const APP_ID = 'app_BWTRIgOs0OoevDfSsBtabRiGffu5wOFU3mkxIxA7NBs'
+const KEY_DEV = 'dev_Bx8i3Bbz1OJBTBAu63NIifr3UwWqUBU5OhHtywo58RY'
+const KEY_PROD = 'prod_A1c7DfHO6XTo2BRwzhkkXKFJ6oaPtoMnRA9xpPSlx74'
+
 const lpRequestMock: Partial<jest.Mocked<LeanplumRequest>> = {
   request: jest.fn()
 }
@@ -120,6 +125,22 @@ describe(LeanplumInternal, () => {
       expect(info).toEqual('test')
       expect(options).toEqual({ devMode: false, queued: true })
     })
+
+    it('works in DEV mode', () => {
+      lp.setAppIdForDevelopmentMode(APP_ID, KEY_DEV)
+      lp.track('Test Purchase', 0.99, 'Development', { dev: true })
+
+      const [action, args, options] = lpRequestMock.request.mock.calls[0]
+      const {event, value, params, info} = args.buildDict()
+
+      expect(lpRequestMock.request).toHaveBeenCalledTimes(1)
+      expect(action).toEqual(Constants.METHODS.TRACK)
+      expect(event).toEqual('Test Purchase')
+      expect(value).toEqual(0.99)
+      expect(params).toEqual(JSON.stringify({ dev: true }))
+      expect(info).toEqual('Development')
+      expect(options).toEqual({ devMode: true, queued: true })
+    })
   })
 
   describe('trackPurchase', () => {
@@ -177,6 +198,21 @@ describe(LeanplumInternal, () => {
       expect(value).toEqual(19.99)
       expect(params).toEqual(JSON.stringify({ itemsInCart: 4, currencyCode: 'BGN' }))
       expect(options).toEqual({ devMode: false, queued: true })
+    })
+
+    it('works in DEV mode', () => {
+      lp.setAppIdForDevelopmentMode(APP_ID, KEY_DEV)
+      lp.trackPurchase(0.99, 'USD', { dev: true }, 'Test Purchase')
+
+      const [action, args, options] = lpRequestMock.request.mock.calls[0]
+      const {event, value, params, info} = args.buildDict()
+
+      expect(lpRequestMock.request).toHaveBeenCalledTimes(1)
+      expect(action).toEqual(Constants.METHODS.TRACK)
+      expect(event).toEqual('Test Purchase')
+      expect(value).toEqual(0.99)
+      expect(params).toEqual(JSON.stringify({ dev: true, currencyCode: 'USD' }))
+      expect(options).toEqual({ devMode: true, queued: true })
     })
   })
 })

--- a/test/specs/LeanplumInternal.test.ts
+++ b/test/specs/LeanplumInternal.test.ts
@@ -52,14 +52,14 @@ describe(LeanplumInternal, () => {
 
   describe('track', () => {
     it('works with event name only', () => {
-      lp.track('Foo')
+      lp.track('Test Event')
 
       const [action, args, options] = lpRequestMock.request.mock.calls[0]
       const {event, value, params, info} = args.buildDict()
 
       expect(lpRequestMock.request).toHaveBeenCalledTimes(1)
       expect(action).toEqual(Constants.METHODS.TRACK)
-      expect(event).toEqual('Foo')
+      expect(event).toEqual('Test Event')
       expect(value).toEqual(0.0)
       expect(params).toEqual(undefined)
       expect(info).toEqual(undefined)
@@ -67,14 +67,14 @@ describe(LeanplumInternal, () => {
     })
 
     it('works with params', () => {
-      lp.track('Foo', { test: true })
+      lp.track('Test Event', { test: true })
 
       const [action, args, options] = lpRequestMock.request.mock.calls[0]
       const {event, value, params, info} = args.buildDict()
 
       expect(lpRequestMock.request).toHaveBeenCalledTimes(1)
       expect(action).toEqual(Constants.METHODS.TRACK)
-      expect(event).toEqual('Foo')
+      expect(event).toEqual('Test Event')
       expect(value).toEqual(0.0)
       expect(params).toEqual(JSON.stringify({ test: true }))
       expect(info).toEqual(undefined)
@@ -82,14 +82,14 @@ describe(LeanplumInternal, () => {
     })
 
     it('works with value', () => {
-      lp.track('Foo', 1.23)
+      lp.track('Test Event', 1.23)
 
       const [action, args, options] = lpRequestMock.request.mock.calls[0]
       const {event, value, params, info} = args.buildDict()
 
       expect(lpRequestMock.request).toHaveBeenCalledTimes(1)
       expect(action).toEqual(Constants.METHODS.TRACK)
-      expect(event).toEqual('Foo')
+      expect(event).toEqual('Test Event')
       expect(value).toEqual(1.23)
       expect(params).toEqual(undefined)
       expect(info).toEqual(undefined)
@@ -97,14 +97,14 @@ describe(LeanplumInternal, () => {
     })
 
     it('works with value and params', () => {
-      lp.track('Foo', 1.23, { test: true })
+      lp.track('Test Event', 1.23, { test: true })
 
       const [action, args, options] = lpRequestMock.request.mock.calls[0]
       const {event, value, params, info} = args.buildDict()
 
       expect(lpRequestMock.request).toHaveBeenCalledTimes(1)
       expect(action).toEqual(Constants.METHODS.TRACK)
-      expect(event).toEqual('Foo')
+      expect(event).toEqual('Test Event')
       expect(value).toEqual(1.23)
       expect(params).toEqual(JSON.stringify({ test: true }))
       expect(info).toEqual(undefined)
@@ -112,14 +112,14 @@ describe(LeanplumInternal, () => {
     })
 
     it('works with value, info and params', () => {
-      lp.track('Foo', 1.23, 'test', { test: true })
+      lp.track('Test Event', 1.23, 'test', { test: true })
 
       const [action, args, options] = lpRequestMock.request.mock.calls[0]
       const {event, value, params, info} = args.buildDict()
 
       expect(lpRequestMock.request).toHaveBeenCalledTimes(1)
       expect(action).toEqual(Constants.METHODS.TRACK)
-      expect(event).toEqual('Foo')
+      expect(event).toEqual('Test Event')
       expect(value).toEqual(1.23)
       expect(params).toEqual(JSON.stringify({ test: true }))
       expect(info).toEqual('test')
@@ -128,14 +128,14 @@ describe(LeanplumInternal, () => {
 
     it('works in DEV mode', () => {
       lp.setAppIdForDevelopmentMode(APP_ID, KEY_DEV)
-      lp.track('Test Purchase', 0.99, 'Development', { dev: true })
+      lp.track('Test Event', 0.99, 'Development', { dev: true })
 
       const [action, args, options] = lpRequestMock.request.mock.calls[0]
       const {event, value, params, info} = args.buildDict()
 
       expect(lpRequestMock.request).toHaveBeenCalledTimes(1)
       expect(action).toEqual(Constants.METHODS.TRACK)
-      expect(event).toEqual('Test Purchase')
+      expect(event).toEqual('Test Event')
       expect(value).toEqual(0.99)
       expect(params).toEqual(JSON.stringify({ dev: true }))
       expect(info).toEqual('Development')
@@ -205,7 +205,7 @@ describe(LeanplumInternal, () => {
       lp.trackPurchase(0.99, 'USD', { dev: true }, 'Test Purchase')
 
       const [action, args, options] = lpRequestMock.request.mock.calls[0]
-      const {event, value, params, info} = args.buildDict()
+      const {event, value, params} = args.buildDict()
 
       expect(lpRequestMock.request).toHaveBeenCalledTimes(1)
       expect(action).toEqual(Constants.METHODS.TRACK)


### PR DESCRIPTION
## Proposed Changes

  - Move tracking tests to `LeanplumInternal.test.ts`.
  - Refactor the tests to use mocks instead of request interceptor.
  - Add more tests to cover all use cases.
