### PR TITLE
chore: add session info to e2e app

### DIFF
--- a/test/e2e/index.html
+++ b/test/e2e/index.html
@@ -9,7 +9,13 @@
     <title>Rondo Web</title>
 
     <style>
-      .requires-setup { display: none; }
+      .requires-setup, .requires-start { display: none; }
+      .session-status {
+        position: fixed;
+        top: 1em;
+        right: 1em;
+        z-index: 1;
+      }
     </style>
   </head>
   <body>
@@ -19,6 +25,15 @@
         <p class="lead">Facilitates testing of the Leanplum Web SDK.</p>
         <p>SDK version: <span id="sdkVersion"></span></p>
       </div>
+
+      <div class="session-status">
+        <span class="requires-setup badge badge-warning">
+          Session not started
+        </span>
+        <span class="requires-start badge badge-success">
+          Session started, user ID: <span class="current-user-id"></span>
+        </span>
+    </div>
 
       <div class="row row-cols-md-2">
         <div class="col mb-3">

--- a/test/e2e/index.js
+++ b/test/e2e/index.js
@@ -42,6 +42,10 @@ $("#start")
         } else {
             Leanplum.start();
         }
+
+      $(".requires-start").removeClass("requires-start");
+      $(".session-status .badge-warning").remove();
+      updateUserId();
     });
 
 $("#forceContentUpdate")
@@ -121,6 +125,7 @@ $("[data-action=setUserId]")
         e.preventDefault();
         const userId = $("#setUserId").val();
         Leanplum.setUserId(userId);
+        updateUserId();
     });
 
 $("[data-action=setUserAttribute]")
@@ -136,11 +141,17 @@ $("[data-action=setUserAttribute]")
 $("#sdkVersion").text(Leanplum.VERSION);
 
 // populate initial info
-$("#userId").val(Leanplum._userId || '');
+updateUserId();
 refreshWebPush();
 
 function refreshWebPush() {
     $("#isWebPushSupported").text(Leanplum.isWebPushSupported() ? "Yes" : "No");
     Leanplum.isWebPushSubscribed()
         .then(isSubscribed => $("#isWebPushSubscribed").text(isSubscribed ? "Yes" : "No"));
+}
+function updateUserId() {
+  // TODO: Leanplum.getUserId
+  const userId = Leanplum._lp._lpRequest.userId;
+  $(".current-user-id").text(userId);
+  $("#setUserId").val(userId);
 }


### PR DESCRIPTION
Adds a session badge to the e2e application. This provides more feedback to the user that a session was not started yet.

<img width="271" alt="image" src="https://user-images.githubusercontent.com/90405/79987246-d3779d00-84b5-11ea-8401-b6e0ae0f8a75.png">
<img width="345" alt="image" src="https://user-images.githubusercontent.com/90405/79987264-d96d7e00-84b5-11ea-8c4b-2c1cbac90113.png">

Tested on [my instance](https://lp-web-sdk-e2e.gyoshev.now.sh/).
