### PR TITLE
chore: fix serviceworker registration for gh-pages

### DIFF
--- a/test/e2e/index.js
+++ b/test/e2e/index.js
@@ -22,7 +22,10 @@ $("[data-action=setup]")
     });
 
 $("#registerForWebPush")
-    .click(() => Leanplum.registerForWebPush().then(refreshWebPush));
+    .click(() => {
+      const swLocation = window.origin + window.pathname + "/sw.min.js";
+      Leanplum.registerForWebPush(swLocation).then(refreshWebPush);
+    });
 
 $("#unregisterFromWebPush")
     .click(() => Leanplum.unregisterFromWebPush().then(refreshWebPush));


### PR DESCRIPTION
The ServiceWorker path is incorrect when running in GH pages. This PR fixes this by removing the hardcoded path.