### PR TITLE
feat: setWebPushOptions method

### DIFF
--- a/src/Leanplum.ts
+++ b/src/Leanplum.ts
@@ -16,7 +16,13 @@
 
 import Constants from './Constants'
 import LeanplumInternal from './LeanplumInternal'
-import { Inbox, SimpleHandler, StatusHandler, UserAttributes } from './types/public'
+import {
+  Inbox,
+  SimpleHandler,
+  StatusHandler,
+  WebPushOptions,
+  UserAttributes
+} from './types/public'
 
 /* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -205,6 +211,10 @@ export default class Leanplum {
    */
   static isWebPushSubscribed(): Promise<boolean> {
     return Leanplum._lp.isWebPushSubscribed()
+  }
+
+  static setWebPushOptions(options: WebPushOptions): void {
+    return Leanplum._lp.setWebPushOptions(options)
   }
 
   /**

--- a/src/Leanplum.ts
+++ b/src/Leanplum.ts
@@ -21,7 +21,7 @@ import {
   SimpleHandler,
   StatusHandler,
   WebPushOptions,
-  UserAttributes
+  UserAttributes,
 } from './types/public'
 
 /* eslint-disable @typescript-eslint/ban-types */

--- a/src/LeanplumInternal.ts
+++ b/src/LeanplumInternal.ts
@@ -29,7 +29,7 @@ import {
   SimpleHandler,
   StatusHandler,
   WebPushOptions,
-  UserAttributes
+  UserAttributes,
 } from './types/public'
 import VarCache from './VarCache'
 
@@ -505,7 +505,7 @@ Use "npm update leanplum-sdk" or go to https://docs.leanplum.com/reference#javas
    */
   registerForWebPush(serviceWorkerUrl?: string): Promise<boolean> {
     if (this._pushManager.isWebPushSupported()) {
-      const subscribe = (isSubscribed) => {
+      const subscribe = (isSubscribed): Promise<boolean> => {
         if (isSubscribed) {
           return Promise.resolve(true)
         }

--- a/src/PushManager.ts
+++ b/src/PushManager.ts
@@ -82,6 +82,7 @@ export default class PushManager {
    */
   public async register(
     serviceWorkerUrl: string,
+    scope: { scope: string } | null,
     callback: (isSubscribed: boolean) => Promise<boolean>
   ): Promise<boolean> {
     if (!this.isWebPushSupported()) {
@@ -92,7 +93,7 @@ export default class PushManager {
     try {
       this.serviceWorkerRegistration = await this.serviceWorker.register(
         serviceWorkerUrl || '/sw.min.js',
-        null
+        scope
       )
 
       const subscription = await this.serviceWorkerRegistration.pushManager.getSubscription()

--- a/src/types/public.ts
+++ b/src/types/public.ts
@@ -43,6 +43,6 @@ export type StatusHandler = (success: boolean) => void
 export type UserAttributes = any
 
 export interface WebPushOptions {
-  serviceWorkerUrl?: string,
-  scope?: string
+  serviceWorkerUrl?: string;
+  scope?: string;
 }

--- a/src/types/public.ts
+++ b/src/types/public.ts
@@ -41,3 +41,8 @@ export type SimpleHandler = () => void
 export type StatusHandler = (success: boolean) => void
 
 export type UserAttributes = any
+
+export interface WebPushOptions {
+  serviceWorkerUrl?: string,
+  scope?: string
+}

--- a/test/e2e/index.js
+++ b/test/e2e/index.js
@@ -21,11 +21,17 @@ $("[data-action=setup]")
         }
     });
 
+let scope = null
+if (window.location.hostname === "leanplum.github.io") {
+  scope = "/Leanplum-JavaScript-SDK/";
+}
+Leanplum.setWebPushOptions({
+  serviceWorkerUrl: window.origin + window.pathname + "/sw.min.js",
+  scope
+})
+
 $("#registerForWebPush")
-    .click(() => {
-      const swLocation = window.origin + window.pathname + "/sw.min.js";
-      Leanplum.registerForWebPush(swLocation).then(refreshWebPush);
-    });
+    .click(() => Leanplum.registerForWebPush().then(refreshWebPush));
 
 $("#unregisterFromWebPush")
     .click(() => Leanplum.unregisterFromWebPush().then(refreshWebPush));

--- a/test/specs/LeanplumInternal.test.ts
+++ b/test/specs/LeanplumInternal.test.ts
@@ -366,7 +366,7 @@ describe(LeanplumInternal, () => {
 
       it('returns `true` when already subscribed', async() => {
         pushManagerMock.isWebPushSupported.mockReturnValueOnce(true)
-        pushManagerMock.register.mockImplementationOnce(async(url, callback) => callback(true))
+        pushManagerMock.register.mockImplementationOnce(async(url, scope, callback) => callback(true))
 
         const result = await lp.registerForWebPush('/sw.test.js')
 
@@ -378,7 +378,7 @@ describe(LeanplumInternal, () => {
 
       it('returns `true` and subscribes user when not subscribed', async() => {
         pushManagerMock.isWebPushSupported.mockReturnValueOnce(true)
-        pushManagerMock.register.mockImplementationOnce(async(url, callback) => callback(false))
+        pushManagerMock.register.mockImplementationOnce(async(url, scope, callback) => callback(false))
         pushManagerMock.subscribeUser.mockReturnValueOnce(Promise.resolve(true))
 
         const result = await lp.registerForWebPush('/sw.test.js')
@@ -387,6 +387,20 @@ describe(LeanplumInternal, () => {
         expect(pushManagerMock.register).toHaveBeenCalledTimes(1)
         expect(pushManagerMock.register.mock.calls[0][0]).toEqual('/sw.test.js')
         expect(pushManagerMock.subscribeUser).toHaveBeenCalledTimes(1)
+      })
+
+      it('uses previously set web push options', async() => {
+        pushManagerMock.isWebPushSupported.mockReturnValueOnce(true)
+        const serviceWorkerUrl = '/lp-sw.min.js'
+        const scope = '/shop/'
+
+        lp.setWebPushOptions({ serviceWorkerUrl, scope })
+
+        const result = await lp.registerForWebPush()
+
+        const registerCall = pushManagerMock.register.mock.calls[0]
+        expect(registerCall[0]).toEqual(serviceWorkerUrl)
+        expect(registerCall[1]).toEqual({ scope })
       })
     })
 

--- a/test/specs/PushManager.test.ts
+++ b/test/specs/PushManager.test.ts
@@ -99,7 +99,7 @@ describe(PushManager, () => {
         register: () => registration
       })
 
-      await pushManager.register('', (x) => Promise.resolve(x))
+      await pushManager.register('', null, (x) => Promise.resolve(x))
 
       subscription = {
         endpoint: 'old_subscription'
@@ -138,7 +138,7 @@ describe(PushManager, () => {
       windowMock.mockReturnValue({} as any)
 
       jest.spyOn(console, 'log').mockImplementationOnce(() => {})
-      await pushManager.register('', callback)
+      await pushManager.register('', null, callback)
 
       expect(callback).toHaveBeenCalledTimes(1)
       expect(callback).toHaveBeenCalledWith(false)
@@ -153,7 +153,7 @@ describe(PushManager, () => {
       })
 
       jest.spyOn(console, 'log').mockImplementationOnce(() => {})
-      await pushManager.register('', callback)
+      await pushManager.register('', null, callback)
 
       expect(callback).toHaveBeenCalledTimes(1)
       expect(callback).toHaveBeenCalledWith(false)
@@ -169,7 +169,7 @@ describe(PushManager, () => {
         })
       })
 
-      await pushManager.register('', callback)
+      await pushManager.register('', null, callback)
 
       expect(callback).toHaveBeenCalledTimes(1)
       expect(callback).toHaveBeenCalledWith(false)
@@ -187,7 +187,7 @@ describe(PushManager, () => {
         })
       })
 
-      await pushManager.register('', callback)
+      await pushManager.register('', null, callback)
 
       expect(callback).toHaveBeenCalledTimes(1)
       expect(callback).toHaveBeenCalledWith(true)
@@ -202,7 +202,7 @@ describe(PushManager, () => {
       })
       mockServiceWorker({ register })
 
-      await pushManager.register('', callback)
+      await pushManager.register('', null, callback)
 
       expect(register).toHaveBeenCalledTimes(1)
       expect(register).toHaveBeenCalledWith('/sw.min.js', null)
@@ -217,7 +217,7 @@ describe(PushManager, () => {
         })
       })
 
-      await pushManager.register('', (x) => Promise.resolve(x))
+      await pushManager.register('', null, (x) => Promise.resolve(x))
 
       expect(createRequestSpy).toHaveBeenCalledTimes(0)
     })
@@ -234,7 +234,7 @@ describe(PushManager, () => {
         })
       })
 
-      await pushManager.register('', (x) => Promise.resolve(x))
+      await pushManager.register('', null, (x) => Promise.resolve(x))
 
       expect(createRequestSpy).toHaveBeenCalledTimes(1)
 
@@ -266,7 +266,7 @@ describe(PushManager, () => {
         })
       })
 
-      await pushManager.register('', (x) => Promise.resolve(x))
+      await pushManager.register('', null, (x) => Promise.resolve(x))
 
       await expect(pushManager.subscribeUser()).rejects.toThrowError()
     })
@@ -281,7 +281,7 @@ describe(PushManager, () => {
         })
       })
 
-      await pushManager.register('', (x) => Promise.resolve(x))
+      await pushManager.register('', null, (x) => Promise.resolve(x))
 
       await expect(pushManager.subscribeUser()).rejects.toThrowError()
     })
@@ -298,7 +298,7 @@ describe(PushManager, () => {
         })
       })
 
-      await pushManager.register('', (x) => Promise.resolve(x))
+      await pushManager.register('', null, (x) => Promise.resolve(x))
 
       expect(await pushManager.subscribeUser()).toBe(true)
     })
@@ -313,7 +313,7 @@ describe(PushManager, () => {
         })
       })
 
-      await pushManager.register('', (x) => Promise.resolve(x))
+      await pushManager.register('', null, (x) => Promise.resolve(x))
       await pushManager.subscribeUser().catch(() => { /* noop - expected */ })
 
       expect(createRequestSpy).toHaveBeenCalledTimes(0)
@@ -332,7 +332,7 @@ describe(PushManager, () => {
         })
       })
 
-      await pushManager.register('', (x) => Promise.resolve(x))
+      await pushManager.register('', null, (x) => Promise.resolve(x))
       await pushManager.subscribeUser()
 
       expect(createRequestSpy).toHaveBeenCalledTimes(1)
@@ -366,7 +366,7 @@ describe(PushManager, () => {
         })
       })
 
-      await pushManager.register('', (x) => Promise.resolve(x))
+      await pushManager.register('', null, (x) => Promise.resolve(x))
 
       await expect(pushManager.unsubscribeUser()).rejects.toThrowError()
     })
@@ -382,7 +382,7 @@ describe(PushManager, () => {
         })
       })
 
-      await pushManager.register('', (x) => Promise.resolve(x))
+      await pushManager.register('', null, (x) => Promise.resolve(x))
 
       await expect(pushManager.unsubscribeUser()).rejects.toThrowError()
     })
@@ -396,7 +396,7 @@ describe(PushManager, () => {
         })
       })
 
-      await pushManager.register('', (x) => Promise.resolve(x))
+      await pushManager.register('', null, (x) => Promise.resolve(x))
 
       await expect(pushManager.unsubscribeUser()).resolves.not.toThrowError()
     })
@@ -413,7 +413,7 @@ describe(PushManager, () => {
         })
       })
 
-      await pushManager.register('', (x) => Promise.resolve(x))
+      await pushManager.register('', null, (x) => Promise.resolve(x))
 
       await expect(pushManager.unsubscribeUser()).resolves.not.toThrowError()
     })


### PR DESCRIPTION
## Background

The ServiceWorker API allows scoping service workers to specific paths in the application (e.g. only under `/shop/`, or in Github Pages). Also, the `registerForWebPush` method can be called as a result of an App Inbox message without parameters, which requires parameters to be set beforehand. 

This PR allows setting the parameters for `registerForWebPush` before running the code.

## Testing

Unit tests.