### PR TITLE
chore: set correct serviceWorker path for gh-pages

### DIFF
--- a/test/e2e/index.js
+++ b/test/e2e/index.js
@@ -24,7 +24,7 @@ $("[data-action=setup]")
 let scope = null;
 let serviceWorkerUrl = "sw.min.js";
 if (window.location.hostname === "leanplum.github.io") {
-  scope = window.location.pathname;
+  scope = window.location.pathname; // GH-pages guarantees ending slash
   serviceWorkerUrl = scope + serviceWorkerUrl;
 }
 Leanplum.setWebPushOptions({ serviceWorkerUrl, scope });

--- a/test/e2e/index.js
+++ b/test/e2e/index.js
@@ -21,14 +21,13 @@ $("[data-action=setup]")
         }
     });
 
-let scope = null
+let scope = null;
+let serviceWorkerUrl = "sw.min.js";
 if (window.location.hostname === "leanplum.github.io") {
-  scope = "/Leanplum-JavaScript-SDK/";
+  scope = window.location.pathname;
+  serviceWorkerUrl = scope + serviceWorkerUrl;
 }
-Leanplum.setWebPushOptions({
-  serviceWorkerUrl: window.origin + window.location.pathname + "/sw.min.js",
-  scope
-})
+Leanplum.setWebPushOptions({ serviceWorkerUrl, scope });
 
 $("#registerForWebPush")
     .click(() => Leanplum.registerForWebPush().then(refreshWebPush));


### PR DESCRIPTION
The full path should not be used, as this throws an error "This operation is not secure".