### PR TITLE
fix: do not set inbox message state to undefined

### DIFF
--- a/src/LeanplumInbox.ts
+++ b/src/LeanplumInbox.ts
@@ -19,9 +19,12 @@ export default class LeanplumInbox implements Inbox {
       queued: true,
       sendNow: true,
       response: (data) => {
-        this.messageMap = data.response[0].newsfeedMessages
+        const response = data.response[0]
+        if (response && response.newsfeedMessages) {
+          this.messageMap = response.newsfeedMessages
 
-        this.triggerChangeHandlers()
+          this.triggerChangeHandlers()
+        }
       },
     })
 

--- a/test/specs/LeanplumInbox.test.ts
+++ b/test/specs/LeanplumInbox.test.ts
@@ -34,6 +34,29 @@ describe(LeanplumInbox, () => {
 
       expect(handler).toHaveBeenCalledTimes(1)
     })
+
+    it('works when reponse does not provide messages', () => {
+      const handler = jest.fn()
+
+      inbox.onChanged(handler)
+
+      createRequestSpy.mockImplementationOnce(
+        (method, args, options) => {
+          options.response({
+            response: [{
+              success:true,
+              warning:{
+                message:"User not found; request skipped."
+              }
+            }]
+          })
+        }
+      )
+      inbox.downloadMessages()
+
+      expect(handler).toHaveBeenCalledTimes(0)
+      expect(inbox.messageIds()).toEqual([])
+    })
   })
 
   describe('allMessages', () => {


### PR DESCRIPTION
Some API responses do not return messages -- do not update the message state for them.