### PR TITLE
fix: remove unneeded import from E2E website

### DIFF
--- a/test/e2e/index.ts
+++ b/test/e2e/index.ts
@@ -1,4 +1,4 @@
-import Leanplum from '../../dist/leanplum'
+declare const Leanplum: typeof import('../../dist/leanplum').default
 
 const isProdKey = (accessKey): boolean => /^prod_/.test(accessKey)
 

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "UMD",
+    "module": "ES6",
     "moduleResolution": "node",
     "outDir": "dist/e2e",
     "rootDir": "./test/e2e"


### PR DESCRIPTION
## Proposed Changes

  - Remove unneeded import from E2E website, which was added because of type defs.
