### PR TITLE
chore: add 'startFromCache' option in E2E test site

### DIFF
--- a/test/e2e/index.html
+++ b/test/e2e/index.html
@@ -109,6 +109,8 @@
 
               <div class="card-actions">
                 <button type="button" class="btn btn-primary" id="start">Start</button>
+
+                <button type="button" class="btn btn-secondary" id="startFromCache">Continue session</button>
               </div>
             </div>
           </div>

--- a/test/e2e/index.ts
+++ b/test/e2e/index.ts
@@ -44,15 +44,16 @@ Leanplum.addVariablesChangedHandler(() => {
     $('#variables').text(json)
 })
 
-$('#start')
-    .click(() => {
-        const userId = $('startUserId').val()
+$('#start,#startFromCache')
+    .click((e) => {
+      const method = $(e.target).attr('id')
+      const userId = $('startUserId').val()
 
-        if (userId) {
-            Leanplum.start(userId)
-        } else {
-            Leanplum.start()
-        }
+      if (userId) {
+          Leanplum[method](userId)
+      } else {
+          Leanplum[method]()
+      }
 
       $('.requires-start').removeClass('requires-start')
       $('.session-status .badge-warning').remove()


### PR DESCRIPTION
Adds a 'Continue session' button to Rondo Web, in order to allow testing of the `startFromCache` method.