### PR TITLE
chore: use state tracking parameters

### DIFF
--- a/test/e2e/index.ts
+++ b/test/e2e/index.ts
@@ -116,8 +116,8 @@ $('[data-action=advanceToState]')
     .submit((e) => {
         e.preventDefault()
         const state = $('#stateName').val() as string
-        const paramKey = $('#eventParamKey').val() as string
-        const paramValue = $('#eventParamValue').val()
+        const paramKey = $('#stateParamKey').val() as string
+        const paramValue = $('#stateParamValue').val()
 
         let params
         if (paramKey && paramValue) {


### PR DESCRIPTION
Prior to this PR, filling out event parameters sends them along with the `advanceToState` call, due to improper wiring.