### PR TITLE
fix: honor the limitUser limit

### DIFF
--- a/src/Messages.ts
+++ b/src/Messages.ts
@@ -422,6 +422,9 @@ export default class Messages {
         if (verb === 'limitSession') {
           const sessionOccurrences = this.occurrenceTracker.getSessionOccurranceCount(id)
           return sessionOccurrences + 1 === noun
+        } else if (verb === 'limitUser') {
+          const occurrences = this.occurrenceTracker.getOccurrences(id).length
+          return occurrences + 1 <= noun
         } else {
           // X in Y (seconds|minutes|days|hours)
           const perInterval = parseInt(limit.objects[0].toString()) || 1

--- a/test/specs/Messages.test.ts
+++ b/test/specs/Messages.test.ts
@@ -608,6 +608,31 @@ describe(Messages, () => {
       events.emit('track', { eventName: 'Add to cart' })
       expect(showMessage).toHaveBeenCalledTimes(3)
     })
+
+    it('honrs limitUser', () => {
+      events.emit('messagesReceived', { "123": {
+        ...MESSAGE_WITH_EVENT_TRIGGER,
+        whenLimits: {
+          verb: "AND",
+          children: [
+            {
+              subject: "times",
+              objects: [],
+              verb: "limitUser",
+              noun: 2,
+              secondaryVerb: "="
+            }
+          ]
+        }
+      } })
+
+      events.emit('track', { eventName: 'Add to cart' })
+      showMessage.mock.calls[0][0].context.track()
+      events.emit('track', { eventName: 'Add to cart' })
+      showMessage.mock.calls[0][0].context.track()
+      events.emit('track', { eventName: 'Add to cart' })
+      expect(showMessage).toHaveBeenCalledTimes(2)
+    })
   })
 
   describe('persistence', () => {


### PR DESCRIPTION
Messages can be limited for a specific user with the `limitUser` limit, and this PR adds support for it.