### PR TITLE
chore: do not crash on empty message title

### DIFF
--- a/test/e2e/index.ts
+++ b/test/e2e/index.ts
@@ -245,8 +245,8 @@ Leanplum.on('showMessage', (args) => {
   let title, body, buttons = [];
 
   if (message.__name__ === 'HTML' && message.__file__Template === 'lp_public_floating-interstitial-10.html') {
-    title = message.Title['Text value'];
-    body = message.Message['Text value'];
+    title = message.Title?.['Text value'];
+    body = message.Message?.['Text value'];
 
     const imageInfo = message['Hero image']
     const imageUrl = imageInfo?.['Image URL']


### PR DESCRIPTION
Previewing a Floating Interstitial with default messages crashes rondo, since they are not serialized from the server. This PR prevents this, albeit not showing the message itself.