### PR TITLE
chore: handle more floating intersititial cases

### DIFF
--- a/test/e2e/index.ts
+++ b/test/e2e/index.ts
@@ -251,7 +251,7 @@ Leanplum.on('showMessage', (args) => {
     const imageInfo = message['Hero image']
     const imageUrl = imageInfo?.['Image URL']
     if (imageUrl) {
-      const imageHtml = `<p><img src="${imageUrl}" width="${imageInfo.width || '100%'}" height="${imageInfo.height || ''}" /></p>`
+      const imageHtml = `<p><img src="${imageUrl}" width="100%" /></p>`
       if (!imageInfo['Display above headline']) {
         body += imageHtml;
       } else {

--- a/test/e2e/index.ts
+++ b/test/e2e/index.ts
@@ -265,7 +265,7 @@ Leanplum.on('showMessage', (args) => {
         console.log(`Could not find ${buttonName} in message: `, message);
         return
       }
-      if ('Show button' in button && !button['Show button']) {
+      if (button['Show button'] === false) {
         return
       }
       buttons.push({

--- a/test/e2e/index.ts
+++ b/test/e2e/index.ts
@@ -265,7 +265,7 @@ Leanplum.on('showMessage', (args) => {
         console.log(`Could not find ${buttonName} in message: `, message);
         return
       }
-      if (!button['Show button']) {
+      if ('Show button' in button && !button['Show button']) {
         return
       }
       buttons.push({


### PR DESCRIPTION
These commits address some issues when showing Floating Interstitials in Rondo Web:

- Hero image is sometimes skewed in preview / live
- Buttons don't show unless their 'show' field is set explicitly to `true`