### PR TITLE
feat: Allow handling Open URL actions in user code

### DIFF
--- a/src/LeanplumInternal.ts
+++ b/src/LeanplumInternal.ts
@@ -74,7 +74,18 @@ export default class LeanplumInternal {
 
   constructor(private wnd: Window) {
     this._browserDetector = new BrowserDetector(wnd)
-    this._events.on('navigationChange', (url) => this.wnd.location.assign(url))
+    this._events.on('navigationChange', (url) => {
+      let prevented = false
+
+      this._events.emit('openUrl', {
+        preventDefault: () => prevented = true,
+        url
+      })
+
+      if (!prevented) {
+        this.wnd.location.assign(url)
+      }
+    })
   }
 
   setApiPath(apiPath: string): void {

--- a/src/LeanplumInternal.ts
+++ b/src/LeanplumInternal.ts
@@ -76,10 +76,9 @@ export default class LeanplumInternal {
     this._browserDetector = new BrowserDetector(wnd)
     this._events.on('navigationChange', (url) => {
       let prevented = false
-
       this._events.emit('openUrl', {
         preventDefault: () => prevented = true,
-        url
+        url,
       })
 
       if (!prevented) {

--- a/src/types/public.ts
+++ b/src/types/public.ts
@@ -44,7 +44,7 @@ export type StatusHandler = (success: boolean) => void
 
 export type UserAttributes = any
 
-export type EventType = 'start' | 'resume' | 'track' | 'setUserAttribute' | 'advanceState' | 'showMessage'
+export type EventType = 'start' | 'resume' | 'track' | 'setUserAttribute' | 'advanceState' | 'showMessage' | 'openUrl'
 
 export interface WebPushOptions {
   serviceWorkerUrl?: string;

--- a/test/specs/LeanplumInternal.test.ts
+++ b/test/specs/LeanplumInternal.test.ts
@@ -816,6 +816,25 @@ describe(LeanplumInternal, () => {
       expect(handler).toHaveBeenCalledTimes(1)
       expect(handler.mock.calls[0][0]).toHaveProperty('actionDefinitions', actionDefinitions)
     })
+
+    it('allows handling of Open URL actions in user code', () => {
+      windowMock.location = { assign: jest.fn() } as any
+      const handler = jest.fn((e) => e.preventDefault())
+      lp.on('openUrl', handler)
+
+      mockNextResponse({ response: [{ success: true }] })
+      lp.onInboxAction('123', {
+        __name__: 'Open URL',
+        URL: 'https://example.com',
+      })
+
+      expect(windowMock.location.assign).toHaveBeenCalledTimes(0)
+      expect(handler).toHaveBeenCalledTimes(1)
+      expect(handler).toHaveBeenCalledWith({
+        url: 'https://example.com',
+        preventDefault: expect.any(Function)
+      })
+    })
   })
 
   describe('Misc', () => {


### PR DESCRIPTION
Allows handling of `Open URL` actions in user code, replacing the default `window.location.assign` code.

Triggers a preventable `openUrl` event that receives the URL to open. User code looks like:

```ts
Leanplum.on('openUrl', function(e) {
  // prevent default open
  e.preventDefault();

  // open in new tab, or use in client-side router, etc.
  window.open(e.url, '_blank');
});
```