### PR TITLE
fix: load message occurrences on start

### DIFF
--- a/src/Messages.ts
+++ b/src/Messages.ts
@@ -136,6 +136,7 @@ export default class Messages {
     events.on('messagesReceived', this.onMessagesReceived.bind(this))
 
     events.on('start', () => {
+      this.occurrenceTracker.load()
       this.occurrenceTracker.clearSession()
       this.onTrigger({ trigger: 'start' })
     })

--- a/test/specs/Messages.test.ts
+++ b/test/specs/Messages.test.ts
@@ -919,6 +919,34 @@ describe(Messages, () => {
 
       expect(showMessage).toHaveBeenCalledTimes(0)
     })
+
+    it('loads session occurrences on start', () => {
+      const now = Date.now()
+
+      events.emit('messagesReceived', { "123": {
+        ...MESSAGE_WITH_EVENT_TRIGGER,
+        whenLimits: {
+          verb: "AND",
+          children: [ { subject: "times", verb: "limitUser", noun: 1 } ],
+        },
+      } })
+
+      jest.spyOn(LocalStorageManager, 'getFromLocalStorage').mockImplementation(
+        (key) => {
+          return JSON.stringify({
+            session: { '123': 1 },
+            triggers: { '123': [ now ] },
+            occurrences: { '123': [ now ] },
+          })
+        }
+      )
+
+      events.emit('start')
+
+      events.emit('track', { eventName: 'Add to cart' })
+
+      expect(showMessage).toHaveBeenCalledTimes(0)
+    })
   })
 
   describe('message preview', () => {


### PR DESCRIPTION
When starting a new session, message occurrences are not loaded initially, which wipes out the occurrence tracker when a new message occurrence is tracked.

This PR resolves this by loading the message occurrences on `start` calls.