### PR TITLE
fix: do not use document.write if srcdoc is available

### DIFF
--- a/src/Messages.ts
+++ b/src/Messages.ts
@@ -361,10 +361,14 @@ export default class Messages {
     const content = template
       .replace('##Vars##', vars)
       .replace('<body>', `<body><script>window.messageId='${messageId}'</script>`)
-    const doc = iframe.contentWindow.document
-    doc.open()
-    doc.write(content)
-    doc.close()
+    if ('srcdoc' in iframe) {
+      iframe.srcdoc = content
+    } else {
+      const doc = iframe.contentWindow.document
+      doc.open()
+      doc.write(content)
+      doc.close()
+    }
   }
 
   trackMessage(

--- a/test/specs/Messages.test.ts
+++ b/test/specs/Messages.test.ts
@@ -1054,7 +1054,8 @@ describe(Messages, () => {
     })
 
     it("renders an iframe with the template content, resolving vars", async () => {
-      Document.prototype.write = jest.fn(() => {})
+      const iframe = document.createElement('iframe')
+      Document.prototype.createElement = jest.fn(() => iframe)
 
       jest.spyOn(Network.prototype, 'ajax').mockImplementationOnce(
         (method, type, data, success) => success('<body>##Vars##</body>')
@@ -1069,7 +1070,7 @@ describe(Messages, () => {
 
       await (new Promise(resolve => setImmediate(resolve)));
       const messageVars = JSON.stringify({ messageId: "12345", ...vars })
-      expect(Document.prototype.write).toHaveBeenCalledWith(
+      expect(iframe.srcdoc).toEqual(
         `<body><script>window.messageId='12345'</script>${messageVars}</body>`
       )
     })


### PR DESCRIPTION
Browser vendors have deprecated support for `document.write`, and this pops us as an issue in the JS SDK.

This PR starts using the `srcdoc` attribute, if available, to render Rich IAM.