### PR TITLE
fix: allow access to additional App Inbox data

### DIFF
--- a/src/LeanplumInbox.ts
+++ b/src/LeanplumInbox.ts
@@ -142,6 +142,7 @@ export class LeanplumInboxMessage implements InboxMessage {
       id,
       messageInfo.messageData?.vars?.Title,
       messageInfo.messageData?.vars?.Subtitle,
+      messageInfo.messageData?.vars?.Data,
       messageInfo.deliveryTimestamp,
       messageInfo.isRead,
       messageInfo.messageData?.vars?.Image,
@@ -153,6 +154,7 @@ export class LeanplumInboxMessage implements InboxMessage {
     private _id: string,
     private _title: string,
     private _subtitle: string,
+    private _data: Record<string, string | number>,
     private _timestamp: number,
     private _isRead: boolean,
     private _imageUrl: string,
@@ -167,6 +169,9 @@ export class LeanplumInboxMessage implements InboxMessage {
   }
   public subtitle(): string {
     return this._subtitle
+  }
+  public data(): Record<string, string | number> {
+    return this._data
   }
   public timestamp(): number {
     return this._timestamp

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -30,6 +30,7 @@ export type MessageObject = {
     vars?: {
       Title: string;
       Subtitle: string;
+      Data?: Record<string, string | number>;
       Image: string;
       'Open action': Action;
     };

--- a/src/types/public.ts
+++ b/src/types/public.ts
@@ -18,6 +18,7 @@ export interface InboxMessage {
   id(): string;
   title(): string;
   subtitle(): string;
+  data(): Record<string, string | number>;
   timestamp(): number;
   isRead(): boolean;
   imageUrl(): string;

--- a/test/specs/LeanplumInbox.test.ts
+++ b/test/specs/LeanplumInbox.test.ts
@@ -166,6 +166,25 @@ describe(LeanplumInbox, () => {
 
       expect(inbox.message('123##1')).toEqual(null)
     })
+
+    it('returns data ', () => {
+      mockMessages({
+        '123##1': createMessage({
+          vars: {
+            Title: 'Target',
+            Data: {
+              text: 'lorem',
+              num: 42
+            }
+          },
+        })
+      })
+
+      expect(inbox.message('123##1').data()).toEqual({
+        text: 'lorem',
+        num: 42
+      })
+    })
   })
 
   describe('read', () => {


### PR DESCRIPTION
Customers can define additional data to send along the app inbox message. Alas, this data is not provided through the SDK API.

This PR allows developers to access the defined data object through a `message.data()` method.