### PR TITLE
feat: handle the 'Register for Push' app function

### DIFF
--- a/src/LeanplumInternal.ts
+++ b/src/LeanplumInternal.ts
@@ -85,6 +85,7 @@ export default class LeanplumInternal {
         this.wnd.location.assign(url)
       }
     })
+    this._events.on('registerForPush', () => this.registerForWebPush())
   }
 
   setApiPath(apiPath: string): void {

--- a/src/Messages.ts
+++ b/src/Messages.ts
@@ -426,6 +426,8 @@ export default class Messages {
     const processAction = (): void => {
       if (action.__name__ === 'Open URL') {
         this.events.emit('navigationChange', action.URL)
+      } else if (action.__name__ === 'Register For Push') {
+        this.events.emit('registerForPush')
       }
     }
     const messageId = this.messageIdFromAction(action)

--- a/src/types/public.ts
+++ b/src/types/public.ts
@@ -37,7 +37,12 @@ export interface OpenURLAction {
   URL: string;
 }
 
-export type Action = ChainMessage | OpenURLAction
+export interface RegisterForPushAction {
+  __name__: 'Register For Push';
+  parentCampaignId?: number;
+}
+
+export type Action = ChainMessage | OpenURLAction | RegisterForPushAction
 
 export type SimpleHandler = () => void
 

--- a/test/specs/LeanplumInternal.test.ts
+++ b/test/specs/LeanplumInternal.test.ts
@@ -835,6 +835,18 @@ describe(LeanplumInternal, () => {
         preventDefault: expect.any(Function)
       })
     })
+
+    it('calls registerForPush when registerForPush event is triggered', () => {
+      mockNextResponse({ response: [{ success: true }] })
+
+      jest.spyOn(lp, 'registerForWebPush').mockResolvedValueOnce(undefined);
+
+      lp.onInboxAction('123', {
+        __name__: 'Register For Push'
+      })
+
+      expect(lp.registerForWebPush).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('Misc', () => {


### PR DESCRIPTION
Enables automatic handling of the `Register For Push` app function.

If the service worker is not located at `/sw.min.js`, or requires a different scope, these can be set through `Leanplum.setWebPushOptions`. This should have been done before handling a `Register For Push` function:

```js
Leanplum.setWebPushOptions({
  serviceWorkerUrl: '/shop/sw.min.js',
  scope: '/shop/'
});
```