### PR TITLE
feat: Support embedded message chaining

### DIFF
--- a/src/Messages.ts
+++ b/src/Messages.ts
@@ -404,7 +404,7 @@ export default class Messages {
     })
   }
 
-  onAction(action: Action, parentMessageId: string = ''): void {
+  onAction(action: Action, parentMessageId = ''): void {
     if (!action) {
       return
     }
@@ -427,7 +427,7 @@ export default class Messages {
 
     // handle app function
     const processAction = (): void => {
-      const name = action.__name__;
+      const name = action.__name__
       if (action.__name__ === 'Open URL') {
         this.events.emit('navigationChange', action.URL)
       } else if (action.__name__ === 'Register For Push') {
@@ -436,7 +436,7 @@ export default class Messages {
         this.showMessage(parentMessageId, {
           messageId: parentMessageId,
           action: name,
-          vars: action as any
+          vars: action as any, // eslint-disable-line
         })
       }
     }

--- a/src/Messages.ts
+++ b/src/Messages.ts
@@ -410,7 +410,7 @@ export default class Messages {
     }
 
     const messages = this._messageCache
-    if (action && action.__name__ === 'Chain to Existing Message') {
+    if (action.__name__ === 'Chain to Existing Message') {
       const chainedMessageId = action['Chained message']
       const message = messages[chainedMessageId]
       if (message.action === 'Open URL') {
@@ -430,6 +430,12 @@ export default class Messages {
         this.events.emit('navigationChange', action.URL)
       } else if (action.__name__ === 'Register For Push') {
         this.events.emit('registerForPush')
+      } else if ('__name__' in action) {
+        this.showMessage('', {
+          messageId: '',
+          action: action as any,
+          vars: action as any
+        })
       }
     }
     const messageId = this.messageIdFromAction(action)

--- a/src/Messages.ts
+++ b/src/Messages.ts
@@ -418,7 +418,6 @@ export default class Messages {
       } else if (message.action === 'Register For Push') {
         this.events.emit('registerForPush')
       } else {
-        // embedded chained message
         this.showMessage(chainedMessageId, message)
       }
 
@@ -433,6 +432,7 @@ export default class Messages {
       } else if (action.__name__ === 'Register For Push') {
         this.events.emit('registerForPush')
       } else if (name) {
+        // embedded chained message
         this.showMessage(parentMessageId, {
           messageId: parentMessageId,
           action: name,

--- a/src/Messages.ts
+++ b/src/Messages.ts
@@ -248,10 +248,10 @@ export default class Messages {
         this.occurrenceTracker.recordOccurrence(id)
         this.trackMessage(id, { event, value, info, params })
       },
-      runActionNamed: (actionName: string): void => this.onAction(vars[actionName]),
+      runActionNamed: (actionName: string): void => this.onAction(vars[actionName], id),
       runTrackedActionNamed: (actionName: string): void => {
         const event = actionName.replace(/ action$/, '')
-        this.trackMessage(id, { event }, () => this.onAction(vars[actionName]))
+        this.trackMessage(id, { event }, () => this.onAction(vars[actionName], id))
       },
     }
 
@@ -404,7 +404,7 @@ export default class Messages {
     })
   }
 
-  onAction(action: Action): void {
+  onAction(action: Action, parentMessageId: string = ''): void {
     if (!action) {
       return
     }
@@ -414,10 +414,11 @@ export default class Messages {
       const chainedMessageId = action['Chained message']
       const message = messages[chainedMessageId]
       if (message.action === 'Open URL') {
-        this.trackMessage(chainedMessageId, { event: 'View' }, () => this.onAction(message.vars))
+        this.trackMessage(chainedMessageId, { event: 'View' }, () => this.onAction(message.vars, chainedMessageId))
       } else if (message.action === 'Register For Push') {
         this.events.emit('registerForPush')
       } else {
+        // embedded chained message
         this.showMessage(chainedMessageId, message)
       }
 
@@ -426,14 +427,15 @@ export default class Messages {
 
     // handle app function
     const processAction = (): void => {
+      const name = action.__name__;
       if (action.__name__ === 'Open URL') {
         this.events.emit('navigationChange', action.URL)
       } else if (action.__name__ === 'Register For Push') {
         this.events.emit('registerForPush')
-      } else if ('__name__' in action) {
-        this.showMessage('', {
-          messageId: '',
-          action: action as any,
+      } else if (name) {
+        this.showMessage(parentMessageId, {
+          messageId: parentMessageId,
+          action: name,
           vars: action as any
         })
       }

--- a/test/specs/Messages.test.ts
+++ b/test/specs/Messages.test.ts
@@ -193,6 +193,7 @@ describe(Messages, () => {
       const secondMessage = showMessage.mock.calls[1][0].message
       expect(secondMessage).toHaveProperty('__name__', 'Confirm')
       expect(secondMessage).toHaveProperty('Title', 'Confirm again')
+      expect(secondMessage).toHaveProperty('messageId', '123')
     })
 
 

--- a/test/specs/Messages.test.ts
+++ b/test/specs/Messages.test.ts
@@ -166,6 +166,36 @@ describe(Messages, () => {
       expect(navigationChange).toHaveBeenCalledWith("https://example.com/success")
     })
 
+    it('triggers showMessage for embedded chained message', () => {
+      events.emit('messagesReceived', {
+        "123": {
+          action: "Confirm",
+          whenTriggers: TRIGGER_ON_START,
+          parentCampaignId: 456,
+          vars: {
+            __name__: "Confirm",
+            "Accept action": {
+              __name__: "Confirm",
+              Title: "Confirm again",
+            }
+          },
+        }
+      })
+
+      events.emit('start')
+
+      expect(showMessage).toHaveBeenCalledTimes(1)
+
+      // trigger accept action
+      showMessage.mock.calls[0][0].context.runActionNamed('Accept action')
+
+      expect(showMessage).toHaveBeenCalledTimes(2)
+      const secondMessage = showMessage.mock.calls[1][0].message
+      expect(secondMessage).toHaveProperty('__name__', 'Confirm')
+      expect(secondMessage).toHaveProperty('Title', 'Confirm again')
+    })
+
+
     it('tracks actions', () => {
       events.emit('messagesReceived', {
         "123": {


### PR DESCRIPTION
When using the Messaging editor, customers can create message chains that are embedded in the message data, rather than using global IDs.

This PR enables support for them.