### PR TITLE
fix: data can be null in the downloadMessages response

### DIFF
--- a/src/LeanplumInbox.ts
+++ b/src/LeanplumInbox.ts
@@ -23,7 +23,7 @@ export default class LeanplumInbox implements Inbox {
       queued: true,
       sendNow: true,
       response: (data) => {
-        const response = data.response[0]
+        const response = data?.response[0]
         if (response && response.newsfeedMessages) {
           this.messageMap = response.newsfeedMessages
 

--- a/test/specs/LeanplumInbox.test.ts
+++ b/test/specs/LeanplumInbox.test.ts
@@ -57,6 +57,22 @@ describe(LeanplumInbox, () => {
       expect(handler).toHaveBeenCalledTimes(0)
       expect(inbox.messageIds()).toEqual([])
     })
+
+    it('works when reponse is called with null', () => {
+      const handler = jest.fn()
+
+      inbox.onChanged(handler)
+
+      createRequestSpy.mockImplementationOnce(
+        (method, args, options) => {
+          options.response(null)
+        }
+      )
+      inbox.downloadMessages()
+
+      expect(handler).toHaveBeenCalledTimes(0)
+      expect(inbox.messageIds()).toEqual([])
+    })
   })
 
   describe('allMessages', () => {


### PR DESCRIPTION
The `response` function in `downloadMessages` is used in case of success and error. When an error happens, this function is sometimes called with null.
