### PR TITLE
Add `setLocale` method

### DIFF
--- a/dist/leanplum.d.ts
+++ b/dist/leanplum.d.ts
@@ -27,6 +27,7 @@ export default class Leanplum {
     static setAppIdForProductionMode(appId: string, accessKey: string): void;
     static setSocketHost(host: string): void;
     static setDeviceId(deviceId: string): void;
+    static setLocale(locale: string): void;
     static setAppVersion(versionName: string): void;
     static setDeviceName(deviceName: string): void;
     static setDeviceModel(deviceModel: string): void;

--- a/src/Leanplum.ts
+++ b/src/Leanplum.ts
@@ -65,6 +65,10 @@ export default class Leanplum {
     Leanplum._lp.setDeviceId(deviceId)
   }
 
+  static setLocale(locale: string): void {
+    Leanplum._lp.setLocale(locale)
+  }
+
   static setAppVersion(versionName: string): void {
     Leanplum._lp.setAppVersion(versionName)
   }

--- a/src/LeanplumInternal.ts
+++ b/src/LeanplumInternal.ts
@@ -125,7 +125,7 @@ export default class LeanplumInternal {
   }
 
   setLocale(locale: string): void {
-    this._locale = locale;
+    this._locale = locale
   }
 
   setAppVersion(versionName: string): void {

--- a/src/LeanplumInternal.ts
+++ b/src/LeanplumInternal.ts
@@ -67,6 +67,7 @@ export default class LeanplumInternal {
 
   private _deviceName: string
   private _deviceModel: string
+  private _locale: string
   private _systemName: string
   private _systemVersion: string
   private _sessionLength: number
@@ -121,6 +122,10 @@ export default class LeanplumInternal {
 
   setDeviceId(deviceId: string): void {
     this._lpRequest.deviceId = deviceId
+  }
+
+  setLocale(locale: string): void {
+    this._locale = locale;
   }
 
   setAppVersion(versionName: string): void {
@@ -294,7 +299,7 @@ export default class LeanplumInternal {
       .add(Constants.PARAMS.SYSTEM_VERSION, (this._systemVersion || '').toString())
       .add(Constants.PARAMS.BROWSER_NAME, this._browserDetector.browser)
       .add(Constants.PARAMS.BROWSER_VERSION, this._browserDetector.version.toString())
-      .add(Constants.PARAMS.LOCALE, Constants.VALUES.DETECT)
+      .add(Constants.PARAMS.LOCALE, this._locale || Constants.VALUES.DETECT)
       .add(Constants.PARAMS.DEVICE_NAME, this._deviceName ||
           `${this._browserDetector.browser} ${this._browserDetector.version}`)
       .add(Constants.PARAMS.DEVICE_MODEL, this._deviceModel || 'Web Browser')

--- a/test/specs/LeanplumInternal.test.ts
+++ b/test/specs/LeanplumInternal.test.ts
@@ -64,6 +64,35 @@ describe(LeanplumInternal, () => {
       expect(newsfeedMessages).toEqual(['123##1', '234##1'])
     })
 
+    it('sends detect locale by default', () => {
+      mockNextResponse({
+        response: [{
+          success: true,
+        }],
+      })
+      lp.start()
+
+      const [method, args] = lpRequestMock.request.mock.calls[0]
+      const { locale } = args.buildDict()
+      expect(method).toBe('start')
+      expect(locale).toEqual('(detect)')
+    })
+
+    it('sends defined locale', () => {
+      mockNextResponse({
+        response: [{
+          success: true,
+        }],
+      })
+      lp.setLocale('it_CH')
+      lp.start()
+
+      const [method, args] = lpRequestMock.request.mock.calls[0]
+      const { locale } = args.buildDict()
+      expect(method).toBe('start')
+      expect(locale).toEqual('it_CH')
+    })
+
     it('synchronizes message inbox, if requested by API', () => {
       mockNextResponse({
         response: [{


### PR DESCRIPTION
## Proposed Changes

Currently the `locale` parameter is sent along when calling `start()`, but there is no way to avoid it being set to `"(detect)"`

This PR introduces `setLocale` which can be called before `start()`, similarly to what can already be done with `setDeviceName`
