### PR TITLE
fix: ignore session length in dev mode

### DIFF
--- a/src/LeanplumInternal.ts
+++ b/src/LeanplumInternal.ts
@@ -275,7 +275,7 @@ export default class LeanplumInternal {
       userAttributes = {}
     }
 
-    if (this.hasActiveSession()) {
+    if (this.hasActiveSession() && !this._internalState.devMode) {
       return this.startFromCache(userId, userAttributes, callback)
     }
 

--- a/test/specs/LeanplumInternal.test.ts
+++ b/test/specs/LeanplumInternal.test.ts
@@ -228,6 +228,23 @@ describe(LeanplumInternal, () => {
 
         expect(lpRequestMock.request).toHaveBeenCalledTimes(3)
       })
+
+      it('always start new session in dev mode', () => {
+        lp.setAppIdForDevelopmentMode(APP_ID, KEY_DEV)
+
+        let currentTime = 0
+        jest.spyOn(Date, 'now').mockImplementation(() => currentTime)
+        lp.useSessionLength(2)
+
+        mockNextResponse({ response: [{ success: true }] })
+        lp.start()
+
+        currentTime = 500
+        mockNextResponse({ response: [{ success: true }] })
+        lp.start()
+
+        expect(lpRequestMock.request).toHaveBeenCalledTimes(2)
+      })
     })
   })
 


### PR DESCRIPTION
Developer sessions require a `start` call to be able to preview messages correctly.