### PR TITLE
fix: App Inbox throws a JS error if sessionStorage is not available

### DIFF
--- a/src/LeanplumInbox.ts
+++ b/src/LeanplumInbox.ts
@@ -1,6 +1,6 @@
 import ArgsBuilder from './ArgsBuilder'
 import Constants from './Constants'
-import LocalStorageManager from './LocalStorageManager'
+import StorageManager from './StorageManager'
 import { CreateRequestFunction, MessageObject } from './types/internal'
 import { Action, Inbox, InboxMessage } from './types/public'
 
@@ -86,7 +86,7 @@ export default class LeanplumInbox implements Inbox {
   }
 
   private save(): void {
-    LocalStorageManager.saveToLocalStorage(
+    StorageManager.save(
       Constants.DEFAULT_KEYS.INBOX_MESSAGES,
       JSON.stringify(this.messageMap),
       'session'
@@ -94,7 +94,7 @@ export default class LeanplumInbox implements Inbox {
   }
 
   private load(): void {
-    const state = LocalStorageManager.getFromLocalStorage(
+    const state = StorageManager.get(
       Constants.DEFAULT_KEYS.INBOX_MESSAGES,
       'session'
     )

--- a/src/LeanplumInbox.ts
+++ b/src/LeanplumInbox.ts
@@ -1,5 +1,6 @@
 import ArgsBuilder from './ArgsBuilder'
 import Constants from './Constants'
+import LocalStorageManager from './LocalStorageManager'
 import { CreateRequestFunction, MessageObject } from './types/internal'
 import { Action, Inbox, InboxMessage } from './types/public'
 
@@ -85,14 +86,18 @@ export default class LeanplumInbox implements Inbox {
   }
 
   private save(): void {
-    sessionStorage.setItem(
+    LocalStorageManager.saveToLocalStorage(
       Constants.DEFAULT_KEYS.INBOX_MESSAGES,
-      JSON.stringify(this.messageMap)
+      JSON.stringify(this.messageMap),
+      'session'
     )
   }
 
   private load(): void {
-    const state = sessionStorage.getItem(Constants.DEFAULT_KEYS.INBOX_MESSAGES)
+    const state = LocalStorageManager.getFromLocalStorage(
+      Constants.DEFAULT_KEYS.INBOX_MESSAGES,
+      'session'
+    )
     this.messageMap = JSON.parse(state) || {}
   }
 

--- a/src/LeanplumInternal.ts
+++ b/src/LeanplumInternal.ts
@@ -21,7 +21,7 @@ import InternalState from './InternalState'
 import LeanplumInbox from './LeanplumInbox'
 import LeanplumRequest from './LeanplumRequest'
 import LeanplumSocket from './LeanplumSocket'
-import LocalStorageManager from './LocalStorageManager'
+import StorageManager from './StorageManager'
 import PushManager from './PushManager'
 import Messages from './Messages'
 import EventEmitter from './EventEmitter'
@@ -406,7 +406,7 @@ Use "npm update leanplum-sdk" or go to https://docs.leanplum.com/reference#javas
       sendNow: true,
       queued: true,
       response: () => {
-        LocalStorageManager.removeFromLocalStorage(SESSION_KEY)
+        StorageManager.remove(SESSION_KEY)
       },
     })
   }
@@ -473,7 +473,7 @@ Use "npm update leanplum-sdk" or go to https://docs.leanplum.com/reference#javas
 
     if (userId) {
       this._lpRequest.userId = userId
-      LocalStorageManager.saveToLocalStorage(Constants.DEFAULT_KEYS.USER_ID, this._lpRequest.userId)
+      StorageManager.save(Constants.DEFAULT_KEYS.USER_ID, this._lpRequest.userId)
     }
   }
 
@@ -635,7 +635,7 @@ Use "npm update leanplum-sdk" or go to https://docs.leanplum.com/reference#javas
     }
 
     const currentTime = Date.now()
-    const lastActive = parseInt(LocalStorageManager.getFromLocalStorage(SESSION_KEY))
+    const lastActive = parseInt(StorageManager.get(SESSION_KEY))
 
     if (isNaN(lastActive)) {
       return false
@@ -649,6 +649,6 @@ Use "npm update leanplum-sdk" or go to https://docs.leanplum.com/reference#javas
   }
 
   private updateSession(): void {
-    LocalStorageManager.saveToLocalStorage(SESSION_KEY, String(Date.now()))
+    StorageManager.save(SESSION_KEY, String(Date.now()))
   }
 }

--- a/src/LeanplumRequest.ts
+++ b/src/LeanplumRequest.ts
@@ -17,7 +17,7 @@
 
 import ArgsBuilder from './ArgsBuilder'
 import Constants from './Constants'
-import LocalStorageManager from './LocalStorageManager'
+import StorageManager from './StorageManager'
 import Network from './Network'
 
 export default class LeanplumRequest {
@@ -214,15 +214,15 @@ export default class LeanplumRequest {
   }
 
   private loadLocal<T>(key: string): T {
-    return LocalStorageManager.getFromLocalStorage(key)
+    return StorageManager.get(key)
   }
 
   private saveLocal<T>(key: string, value: T): void {
-    LocalStorageManager.saveToLocalStorage(key, value)
+    StorageManager.save(key, value)
   }
 
   private removeLocal(key: string): void {
-    LocalStorageManager.removeFromLocalStorage(key)
+    StorageManager.remove(key)
   }
 }
 

--- a/src/LocalStorageManager.ts
+++ b/src/LocalStorageManager.ts
@@ -16,44 +16,65 @@
  *
  */
 
-let localStorageEnabled
-const alternateLocalStorage = {}
+const storageEnabled = {
+  local: true,
+  session: true,
+}
+const alternateStorage = {
+  local: {},
+  session: {},
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Value = any
+type StorageType = 'local' | 'session'
 
 export default class LocalStorageManager {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  static getFromLocalStorage(key): any {
-    if (localStorageEnabled === false) {
-      return alternateLocalStorage[key]
+  static getFromLocalStorage(key: string, type: StorageType = 'local'): Value {
+    if (!storageEnabled[type]) {
+      return alternateStorage[type][key]
     }
 
-    return localStorage[key]
+    if (type === 'local') {
+      return localStorage[key]
+    } else {
+      return sessionStorage.getItem(key)
+    }
   }
 
-  static saveToLocalStorage(key, value): void {
-    if (localStorageEnabled === false) {
-      alternateLocalStorage[key] = value
+  static saveToLocalStorage(key: string, value: Value, type: StorageType = 'local'): void {
+    if (!storageEnabled[type]) {
+      alternateStorage[type][key] = value
       return
     }
 
     try {
-      localStorage[key] = value
+      if (type === 'local') {
+        localStorage[key] = value
+      } else {
+        sessionStorage.setItem(key, value)
+      }
     } catch (e) {
-      localStorageEnabled = false
-      alternateLocalStorage[key] = value
+      storageEnabled[type] = false
+      alternateStorage[type][key] = value
     }
   }
 
-  static removeFromLocalStorage(key): void {
-    if (localStorageEnabled === false) {
-      delete alternateLocalStorage[key]
+  static removeFromLocalStorage(key: string, type: StorageType = 'local'): void {
+    if (!storageEnabled[type]) {
+      delete alternateStorage[type][key]
       return
     }
 
     try {
-      localStorage.removeItem(key)
+      if (type === 'local') {
+        localStorage.removeItem(key)
+      } else {
+        sessionStorage.removeItem(key)
+      }
     } catch (e) {
-      localStorageEnabled = false
-      delete alternateLocalStorage[key]
+      storageEnabled[type] = false
+      delete alternateStorage[type][key]
     }
   }
 }

--- a/src/Messages.ts
+++ b/src/Messages.ts
@@ -5,7 +5,7 @@ import { CreateRequestFunction, Message, MessageVariables } from './types/intern
 import EventEmitter from './EventEmitter'
 import Network from './Network'
 import isEqual from 'lodash.isequal'
-import LocalStorageManager from './LocalStorageManager'
+import StorageManager from './StorageManager'
 import ValueTransforms from './ValueTransforms'
 
 /* eslint-disable @typescript-eslint/ban-types */
@@ -76,7 +76,7 @@ class OccurrenceTracker {
   }
 
   load(): void {
-    const cache = LocalStorageManager.getFromLocalStorage(Constants.DEFAULT_KEYS.MESSAGE_OCCURRENCES)
+    const cache = StorageManager.get(Constants.DEFAULT_KEYS.MESSAGE_OCCURRENCES)
     if (cache) {
       const json = JSON.parse(cache)
       this.session = json.session
@@ -87,7 +87,7 @@ class OccurrenceTracker {
 
   save(): void {
     const key = Constants.DEFAULT_KEYS.MESSAGE_OCCURRENCES
-    LocalStorageManager.saveToLocalStorage(key, JSON.stringify({
+    StorageManager.save(key, JSON.stringify({
       session: this.session,
       triggers: this.triggers,
       occurrences: this.occurrences,
@@ -131,7 +131,7 @@ export default class Messages {
     })
     events.on('resume', () => {
       const key = Constants.DEFAULT_KEYS.MESSAGE_CACHE
-      const cache = LocalStorageManager.getFromLocalStorage(key)
+      const cache = StorageManager.get(key)
       this._messageCache = cache ? JSON.parse(cache) : this._messageCache
 
       this.occurrenceTracker.load()
@@ -201,7 +201,7 @@ export default class Messages {
   onMessagesReceived(receivedMessages): void {
     const messages = receivedMessages || {}
     this._messageCache = messages
-    LocalStorageManager.saveToLocalStorage(Constants.DEFAULT_KEYS.MESSAGE_CACHE, JSON.stringify(messages))
+    StorageManager.save(Constants.DEFAULT_KEYS.MESSAGE_CACHE, JSON.stringify(messages))
   }
 
   shouldShowMessage(id: string, message, context: TriggerContext): boolean {

--- a/src/PushManager.ts
+++ b/src/PushManager.ts
@@ -17,7 +17,7 @@
 
 import ArgsBuilder from './ArgsBuilder'
 import Constants from './Constants'
-import LocalStorageManager from './LocalStorageManager'
+import StorageManager from './StorageManager'
 import { CreateRequestFunction } from './types/internal'
 
 const APPLICATION_SERVER_PUBLIC_KEY =
@@ -193,12 +193,12 @@ export default class PushManager {
     if (subscription) {
       const preparedSubscription = this.prepareSubscription(subscription)
       const preparedSubscriptionString = JSON.stringify(preparedSubscription)
-      const existingSubscriptionString = LocalStorageManager.getFromLocalStorage(
+      const existingSubscriptionString = StorageManager.get(
         Constants.DEFAULT_KEYS.PUSH_SUBSCRIPTION
       ) as string
 
       if (existingSubscriptionString !== preparedSubscriptionString) {
-        LocalStorageManager.saveToLocalStorage(
+        StorageManager.save(
           Constants.DEFAULT_KEYS.PUSH_SUBSCRIPTION,
           preparedSubscriptionString
         )

--- a/src/StorageManager.ts
+++ b/src/StorageManager.ts
@@ -29,8 +29,8 @@ const alternateStorage = {
 type Value = any
 type StorageType = 'local' | 'session'
 
-export default class LocalStorageManager {
-  static getFromLocalStorage(key: string, type: StorageType = 'local'): Value {
+export default class StorageManager {
+  static get(key: string, type: StorageType = 'local'): Value {
     if (!storageEnabled[type]) {
       return alternateStorage[type][key]
     }
@@ -42,7 +42,7 @@ export default class LocalStorageManager {
     }
   }
 
-  static saveToLocalStorage(key: string, value: Value, type: StorageType = 'local'): void {
+  static save(key: string, value: Value, type: StorageType = 'local'): void {
     if (!storageEnabled[type]) {
       alternateStorage[type][key] = value
       return
@@ -60,7 +60,7 @@ export default class LocalStorageManager {
     }
   }
 
-  static removeFromLocalStorage(key: string, type: StorageType = 'local'): void {
+  static remove(key: string, type: StorageType = 'local'): void {
     if (!storageEnabled[type]) {
       delete alternateStorage[type][key]
       return

--- a/src/VarCache.ts
+++ b/src/VarCache.ts
@@ -16,7 +16,7 @@
 
 import ArgsBuilder from './ArgsBuilder'
 import Constants from './Constants'
-import LocalStorageManager from './LocalStorageManager'
+import StorageManager from './StorageManager'
 import { CreateRequestFunction } from './types/internal'
 import { ActionParameter, MessageTemplateOptions } from './types/public'
 import ValueTransforms from './ValueTransforms'
@@ -188,11 +188,11 @@ export default class VarCache {
   }
 
   private loadLocal<T>(key: string): T {
-    return LocalStorageManager.getFromLocalStorage(key)
+    return StorageManager.get(key)
   }
 
   private saveLocal<T>(key: string, value: T): void {
-    LocalStorageManager.saveToLocalStorage(key, value)
+    StorageManager.save(key, value)
   }
 }
 

--- a/test/specs/LeanplumInbox.test.ts
+++ b/test/specs/LeanplumInbox.test.ts
@@ -41,7 +41,7 @@ describe(LeanplumInbox, () => {
       inbox.onChanged(handler)
 
       createRequestSpy.mockImplementationOnce(
-        (method, args, options) => {
+        (_, __, options) => {
           options.response({
             response: [{
               success:true,
@@ -64,7 +64,7 @@ describe(LeanplumInbox, () => {
       inbox.onChanged(handler)
 
       createRequestSpy.mockImplementationOnce(
-        (method, args, options) => {
+        (_, __, options) => {
           options.response(null)
         }
       )
@@ -441,7 +441,7 @@ describe(LeanplumInbox, () => {
 
   function mockMessages(newsfeedMessages: any): void {
     createRequestSpy.mockImplementationOnce(
-      (method, args, options) => {
+      (_, __, options) => {
         options.response({
           response: [ { newsfeedMessages } ],
         })

--- a/test/specs/LeanplumIntegration.test.ts
+++ b/test/specs/LeanplumIntegration.test.ts
@@ -14,7 +14,6 @@
  *  limitations under the License.
  */
 
-import Constants from '../../src/Constants'
 import LeanplumInternal from '../../src/LeanplumInternal'
 import { startResponse } from '../data/responses'
 import { windowMock } from '../mocks/external'

--- a/test/specs/LeanplumRequest.test.ts
+++ b/test/specs/LeanplumRequest.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import LeanplumRequest from '../../src/LeanplumRequest'
-import LocalStorageManager from '../../src/LocalStorageManager'
+import StorageManager from '../../src/StorageManager'
 import Constants from '../../src/Constants'
 import Network from '../../src/Network'
 import ArgsBuilder from  '../../src/ArgsBuilder'
@@ -32,7 +32,7 @@ describe(LeanplumRequest, () => {
 
   describe('userId resolution', () => {
     beforeEach(() => {
-      lsGetSpy = jest.spyOn(LocalStorageManager, 'getFromLocalStorage').mockReturnValue(undefined)
+      lsGetSpy = jest.spyOn(StorageManager, 'get').mockReturnValue(undefined)
     })
 
     afterEach(() => {

--- a/test/specs/VarCache.test.ts
+++ b/test/specs/VarCache.test.ts
@@ -1,5 +1,5 @@
 import Constants from '../../src/Constants'
-import LocalStorageManager from '../../src/LocalStorageManager'
+import StorageManager from '../../src/StorageManager'
 import VarCache from '../../src/VarCache'
 import { ActionParameterType, MessageKind } from '../../src/types/public'
 
@@ -81,10 +81,10 @@ describe(VarCache, () => {
   })
 
   describe('loadDiffs', () => {
-    let spy: jest.Mocked<LocalStorageManager>
+    let spy: jest.Mocked<StorageManager>
 
     beforeEach(() => {
-      spy = jest.spyOn(LocalStorageManager, 'getFromLocalStorage')
+      spy = jest.spyOn(StorageManager, 'get')
     })
 
     afterEach(() => {
@@ -104,10 +104,10 @@ describe(VarCache, () => {
   })
 
   describe('saveDiffs', () => {
-    let spy: jest.Mocked<LocalStorageManager>
+    let spy: jest.Mocked<StorageManager>
 
     beforeEach(() => {
-      spy = jest.spyOn(LocalStorageManager, 'saveToLocalStorage')
+      spy = jest.spyOn(StorageManager, 'save')
     })
 
     afterEach(() => {


### PR DESCRIPTION
Some browsers and add-ons stop the `sessionStorage` API (e.g. when users disable cookies).

This PR adds an in-memory fallback. This way:
- there is no raised exception
- SPAs continue to work optimally