### PR TITLE
feat: enable dynamic API endpoint configuration

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -105,6 +105,7 @@ export default {
     VARIANTS: '__leanplum_variants',
     VARIANT_DEBUG_INFO: '__leanplum_variant_debug_info',
     ACTION_DEFINITIONS: '__leanplum_action_definitions',
+    HOST_CONFIG: '__leanplum_hosts',
     INBOX_MESSAGES: '__leanplum_inbox_messages',
     TOKEN: '__leanplum_token',
     DEVICE_ID: '__leanplum_device_id',

--- a/src/LeanplumInternal.ts
+++ b/src/LeanplumInternal.ts
@@ -88,12 +88,8 @@ export default class LeanplumInternal {
       }
     })
     this._events.on('registerForPush', () => this.registerForWebPush())
-    this._events.on('updateDevServerHost', (host: string) => {
-      this.setSocketHost(host)
-      if (this._internalState.devMode) {
-        this.connectSocket()
-      }
-    })
+    this._events.on('updateDevServerHost',
+      (host: string) => this.setSocketHost(host))
   }
 
   setApiPath(apiPath: string): void {

--- a/src/LeanplumInternal.ts
+++ b/src/LeanplumInternal.ts
@@ -90,7 +90,9 @@ export default class LeanplumInternal {
     this._events.on('registerForPush', () => this.registerForWebPush())
     this._events.on('updateDevServerHost', (host: string) => {
       this.setSocketHost(host)
-      this.connectSocket()
+      if (this._internalState.devMode) {
+        this.connectSocket()
+      }
     })
   }
 

--- a/src/LeanplumInternal.ts
+++ b/src/LeanplumInternal.ts
@@ -51,7 +51,7 @@ export default class LeanplumInternal {
     this.createRequest.bind(this),
     this.onInboxAction.bind(this)
   )
-  private _lpRequest: LeanplumRequest = new LeanplumRequest()
+  private _lpRequest: LeanplumRequest = new LeanplumRequest(this._events)
   private _varCache: VarCache = new VarCache(this.createRequest.bind(this))
   private _lpSocket: LeanplumSocket = new LeanplumSocket(
     this._varCache,
@@ -88,6 +88,10 @@ export default class LeanplumInternal {
       }
     })
     this._events.on('registerForPush', () => this.registerForWebPush())
+    this._events.on('updateDevServerHost', (host: string) => {
+      this.setSocketHost(host)
+      this.connectSocket()
+    })
   }
 
   setApiPath(apiPath: string): void {

--- a/src/LeanplumRequest.ts
+++ b/src/LeanplumRequest.ts
@@ -19,6 +19,7 @@ import ArgsBuilder from './ArgsBuilder'
 import Constants from './Constants'
 import StorageManager from './StorageManager'
 import Network from './Network'
+import EventEmitter from './EventEmitter'
 
 export default class LeanplumRequest {
   private cooldownTimeout = null
@@ -34,6 +35,7 @@ export default class LeanplumRequest {
   public versionName: string
 
   constructor(
+    private events: EventEmitter,
     private network = new Network()
   ) { }
 
@@ -90,9 +92,8 @@ export default class LeanplumRequest {
     }
 
     if (params.body()) {
-      this.network.ajax(
-        'POST',
-        `${this.apiPath}?${argsBuilder.build()}`,
+      this.sendRequest(
+        `?${argsBuilder.build()}`,
         params.body(),
         success,
         error,
@@ -115,9 +116,8 @@ export default class LeanplumRequest {
             .add(Constants.PARAMS.ACTION, Constants.METHODS.MULTI)
             .add(Constants.PARAMS.TIME, (new Date().getTime() / 1000).toString().toString())
             .build()
-        this.network.ajax(
-          'POST',
-          `${this.apiPath}?${multiRequestArgs}`,
+        this.sendRequest(
+          `?${multiRequestArgs}`,
           requestData,
           success,
           error,
@@ -179,6 +179,12 @@ export default class LeanplumRequest {
     return (count > 0) ? response?.response?.[count - 1] : null
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public getFirstResponse(response): any {
+    const count = response?.response?.length ?? 0
+    return (count > 0) ? response?.response?.[0] : null
+  }
+
   public isResponseSuccess(response): boolean {
     return Boolean(response?.success)
   }
@@ -189,6 +195,28 @@ export default class LeanplumRequest {
     this.saveLocal(itemKey, JSON.stringify(args))
     count++
     this.saveLocal(Constants.DEFAULT_KEYS.COUNT, count)
+  }
+
+  private sendRequest(query: string, data: string, success: Function, error: Function, queued: boolean): void {
+    this.network.ajax(
+      'POST',
+      `${this.apiPath}${query}`,
+      data,
+      (response) => {
+        const methodResponse = this.getFirstResponse(response)
+        if (!methodResponse.success && methodResponse.apiHost) {
+          const { apiHost, apiPath, devServerHost } = methodResponse
+          this.apiPath = `https://${apiHost}/${apiPath}`
+          this.sendRequest(query, data, success, error, queued)
+
+          this.events.emit('updateDevServerHost', devServerHost)
+        } else {
+          success(response)
+        }
+      },
+      error,
+      queued
+    )
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/LeanplumRequest.ts
+++ b/src/LeanplumRequest.ts
@@ -218,7 +218,7 @@ export default class LeanplumRequest {
           this.saveLocal(Constants.DEFAULT_KEYS.HOST_CONFIG, JSON.stringify({
             apiHost,
             apiPath,
-            devServerHost
+            devServerHost,
           }))
           this.apiPath = `https://${apiHost}/${apiPath}`
           this.sendRequest(query, data, success, error, queued)

--- a/src/Network.ts
+++ b/src/Network.ts
@@ -71,7 +71,7 @@ export default class Network {
         handled = true
 
         let response
-        let ranCallback = false
+        let parseError = false
         if (plainText) {
           response = xhr.responseText
         } else {
@@ -83,11 +83,11 @@ export default class Network {
                 error(null, xhr)
               }
             }, 0)
-            ranCallback = true
+            parseError = true
           }
         }
 
-        if (!ranCallback) {
+        if (!parseError) {
           if (xhr.status >= 200 && xhr.status < 300) {
             setTimeout(() => {
               if (success) {
@@ -133,7 +133,7 @@ export default class Network {
     const xdr = new XDomainRequest()
     xdr.onload = () => {
       let response
-      let ranCallback = false
+      let parseError = false
       if (plainText) {
         response = xdr.responseText
       } else {
@@ -145,10 +145,10 @@ export default class Network {
               error(null, xdr)
             }
           }, 0)
-          ranCallback = true
+          parseError = true
         }
       }
-      if (!ranCallback) {
+      if (!parseError) {
         setTimeout(() => {
           if (success) {
             success(response, xdr)

--- a/src/Network.ts
+++ b/src/Network.ts
@@ -179,7 +179,7 @@ export default class Network {
 
   /**
    * Adds the request to the request queue.
-   * @param {Arguments} requestArguments The request arguments from the initial method call.
+   * @param requestArguments The request arguments from the initial method call.
    * @private
    */
   private enqueueRequest(requestArguments): void {

--- a/src/SocketIoClient.ts
+++ b/src/SocketIoClient.ts
@@ -41,12 +41,12 @@ export default class SocketIoClient {
 
   /**
    * Connects to the given socketHost.
-   * @param  {string} socketHost The host to connect to.
+   * @param socketHost The host to connect to.
    */
-  public connect(socketHost): void {
+  public connect(socketHost: string): void {
     this.connecting = true
     this.network.ajax('POST', `https://${socketHost}/socket.io/1`, '',
-        (line) => {
+        (line: string) => {
           const parts = line.split(':')
           const session = parts[0]
           const heartbeat = parseInt(parts[1]) / 2 * 1000
@@ -99,12 +99,18 @@ export default class SocketIoClient {
     )
   }
 
+  public disconnect(): void {
+    this.socket.close()
+    this.connected = false
+    this.connecting = false
+  }
+
   /**
    * Sends given event with arguments to the server.
-   * @param  {string} name Name of the event.
-   * @param  {*} args Arguments to send.
+   * @param name Name of the event.
+   * @param args Arguments to send.
    */
-  public send(name, args): void {
+  public send(name: string, args): void {
     if (!this.connected) {
       console.log('Leanplum: Socket is not connected.')
       return
@@ -118,9 +124,9 @@ export default class SocketIoClient {
 
   /**
    * Sets the network timeout.
-   * @param {number} seconds The timeout in seconds.
+   * @param The timeout in seconds.
    */
-  public setNetworkTimeout(seconds): void {
+  public setNetworkTimeout(seconds: number): void {
     this.network.setNetworkTimeout(seconds)
   }
 }

--- a/test/mocks/internal.ts
+++ b/test/mocks/internal.ts
@@ -11,6 +11,7 @@ export const lpRequestMock: Partial<jest.Mocked<LeanplumRequest>> = {
 
 export const lpSocketMock = {
   connect: jest.fn(),
+  setSocketHost: jest.fn(),
 }
 
 export const pushManagerMock: Partial<jest.Mocked<PushManager>> = {

--- a/test/specs/LeanplumInternal.test.ts
+++ b/test/specs/LeanplumInternal.test.ts
@@ -18,7 +18,7 @@
 
 import Constants from '../../src/Constants'
 import LeanplumInternal from '../../src/LeanplumInternal'
-import { APP_ID, KEY_DEV, KEY_PROD } from '../data/constants'
+import { APP_ID, KEY_DEV } from '../data/constants'
 import { windowMock } from '../mocks/external'
 import { lpRequestMock, lpSocketMock, mockNextResponse, pushManagerMock, varCacheMock } from '../mocks/internal'
 
@@ -43,7 +43,7 @@ describe(LeanplumInternal, () => {
     it('passes available message IDs to API', () => {
       const inbox = lp.inbox()
       lpRequestMock.request.mockImplementationOnce(
-        (method, args, options) => {
+        (_method, _args, options) => {
           options.response({
             success: true,
             response: [ { newsfeedMessages: {
@@ -924,26 +924,12 @@ describe(LeanplumInternal, () => {
 
     describe('devserver host updates', () => {
       it('reconnects to new host on update', () => {
-        lp.setAppIdForDevelopmentMode(APP_ID, KEY_DEV)
         jest.spyOn(lp, 'setSocketHost');
 
         (lp as any)._events.emit('updateDevServerHost', 'dev2.leanplum.com')
 
         expect(lp.setSocketHost).toHaveBeenCalledTimes(1)
         expect(lp.setSocketHost).toHaveBeenCalledWith('dev2.leanplum.com')
-        expect(lpSocketMock.connect).toHaveBeenCalledTimes(1)
-      })
-
-      it('does not connect to dev server in prod mode', () => {
-        lp.setAppIdForProductionMode(APP_ID, KEY_PROD)
-
-        jest.spyOn(lp, 'setSocketHost');
-
-        (lp as any)._events.emit('updateDevServerHost', 'dev2.leanplum.com')
-
-        expect(lp.setSocketHost).toHaveBeenCalledTimes(1)
-        expect(lp.setSocketHost).toHaveBeenCalledWith('dev2.leanplum.com')
-        expect(lpSocketMock.connect).toHaveBeenCalledTimes(0)
       })
     })
   })

--- a/test/specs/LeanplumInternal.test.ts
+++ b/test/specs/LeanplumInternal.test.ts
@@ -18,7 +18,7 @@
 
 import Constants from '../../src/Constants'
 import LeanplumInternal from '../../src/LeanplumInternal'
-import { APP_ID, KEY_DEV } from '../data/constants'
+import { APP_ID, KEY_DEV, KEY_PROD } from '../data/constants'
 import { windowMock } from '../mocks/external'
 import { lpRequestMock, lpSocketMock, mockNextResponse, pushManagerMock, varCacheMock } from '../mocks/internal'
 
@@ -924,6 +924,7 @@ describe(LeanplumInternal, () => {
 
     describe('devserver host updates', () => {
       it('reconnects to new host on update', () => {
+        lp.setAppIdForDevelopmentMode(APP_ID, KEY_DEV)
         jest.spyOn(lp, 'setSocketHost');
 
         (lp as any)._events.emit('updateDevServerHost', 'dev2.leanplum.com')
@@ -931,6 +932,18 @@ describe(LeanplumInternal, () => {
         expect(lp.setSocketHost).toHaveBeenCalledTimes(1)
         expect(lp.setSocketHost).toHaveBeenCalledWith('dev2.leanplum.com')
         expect(lpSocketMock.connect).toHaveBeenCalledTimes(1)
+      })
+
+      it('does not connect to dev server in prod mode', () => {
+        lp.setAppIdForProductionMode(APP_ID, KEY_PROD)
+
+        jest.spyOn(lp, 'setSocketHost');
+
+        (lp as any)._events.emit('updateDevServerHost', 'dev2.leanplum.com')
+
+        expect(lp.setSocketHost).toHaveBeenCalledTimes(1)
+        expect(lp.setSocketHost).toHaveBeenCalledWith('dev2.leanplum.com')
+        expect(lpSocketMock.connect).toHaveBeenCalledTimes(0)
       })
     })
   })

--- a/test/specs/LeanplumInternal.test.ts
+++ b/test/specs/LeanplumInternal.test.ts
@@ -921,6 +921,18 @@ describe(LeanplumInternal, () => {
         expect(varCacheMock.clearUserContent).toHaveBeenCalledTimes(1)
       })
     })
+
+    describe('devserver host updates', () => {
+      it('reconnects to new host on update', () => {
+        jest.spyOn(lp, 'setSocketHost');
+
+        (lp as any)._events.emit('updateDevServerHost', 'dev2.leanplum.com')
+
+        expect(lp.setSocketHost).toHaveBeenCalledTimes(1)
+        expect(lp.setSocketHost).toHaveBeenCalledWith('dev2.leanplum.com')
+        expect(lpSocketMock.connect).toHaveBeenCalledTimes(1)
+      })
+    })
   })
 
   describe('getFileUrl', () => {

--- a/test/specs/LeanplumRequest.test.ts
+++ b/test/specs/LeanplumRequest.test.ts
@@ -31,6 +31,7 @@ describe(LeanplumRequest, () => {
   })
 
   afterEach(() => {
+    localStorage.clear()
     jest.useRealTimers()
   })
 
@@ -281,7 +282,37 @@ describe(LeanplumRequest, () => {
     })
 
     it('persists api path', () => {
-      // TODO: reinit request
+      mockResponses(network, [
+        {
+          "response": [
+            {
+              "success": false,
+              "apiHost": "api2.leanplum.com",
+              "apiPath": "new-api",
+              "devServerHost": "dev2.leanplum.com",
+              "error": {
+                "message": "..."
+              }
+            }
+          ]
+        },
+        {
+          "response": [
+            {
+              "success": true
+            }
+          ]
+        }
+      ])
+
+      request.request('track', args(1), { sendNow: true })
+
+      requestInstance(network)
+
+      request.request('track', args(2), { sendNow: true })
+
+      const calls = (network.ajax as jest.Mock).mock.calls;
+      expect(calls[2][1]).toMatch('https://api2.leanplum.com/new-api')
     })
   });
 })

--- a/test/specs/LeanplumSocket.test.ts
+++ b/test/specs/LeanplumSocket.test.ts
@@ -2,20 +2,26 @@ import LeanplumSocket from '../../src/LeanplumSocket'
 import EventEmitter from '../../src/EventEmitter'
 import VarCache from '../../src/VarCache'
 import { varCacheMock } from '../mocks/internal'
+import { APP_ID } from '../data/constants'
 
 jest.mock('../../src/SocketIoClient');
 jest.mock('../../src/VarCache', () => jest.fn().mockImplementation(() => varCacheMock))
 
 describe(LeanplumSocket, () => {
   let events, socket, createRequest, varCache
+  const AUTH_INFO = {
+    appId: APP_ID,
+    deviceId: 'js-sdk-test-device'
+  }
 
   beforeEach(() => {
     createRequest = jest.fn()
     varCache = new VarCache(createRequest)
     events = new EventEmitter()
     socket = new LeanplumSocket(varCache, createRequest, (r) => r.response[0], events)
-    socket.connect()
+    socket.connect(AUTH_INFO)
     jest.spyOn(socket.socketClient, 'send')
+    jest.spyOn(socket, 'connect')
   })
 
   const MESSAGE = {
@@ -69,5 +75,15 @@ describe(LeanplumSocket, () => {
     expect(varCacheMock.sendActions).toHaveBeenCalledTimes(1)
     expect(socket.socketClient.send).toHaveBeenCalledTimes(1);
     expect(socket.socketClient.send).toHaveBeenCalledWith('getContentResponse', { updated: true });
+  })
+
+  it('reconnects when changing socket host', () => {
+    const NEW_HOST = 'dev2.leanplum.com'
+    socket.socketClient.connected = true
+
+    socket.setSocketHost(NEW_HOST)
+
+    expect(socket.connect).toHaveBeenCalledWith(AUTH_INFO);
+    expect(socket.socketClient.connect).toHaveBeenCalledWith(NEW_HOST);
   })
 })


### PR DESCRIPTION
Allows the Leanplum API to change the endpoints that handle traffic dynamically.

### Implementation

- When a request returns `success: false` and the `apiHost` field, the request is retried on the new endpoint
- The updated configuration is persisted on the device and used for all subsequent requests