### PR TITLE
fix: correctly track in-app message event parameters

### DIFF
--- a/src/Messages.ts
+++ b/src/Messages.ts
@@ -112,6 +112,14 @@ const verbToInterval = (verb: string): number => {
   }
 }
 
+const maybeJSON = (str: string): Object | undefined => {
+  try {
+    return JSON.parse(str)
+  } catch (e) {
+    return undefined
+  }
+}
+
 export default class Messages {
   private _messageCache: MessageHash = {}
   private occurrenceTracker = new OccurrenceTracker()
@@ -293,8 +301,8 @@ export default class Messages {
         context.track(
           params.event,
           parseFloat(params.value),
-          params.parameters,
-          params.info
+          params.info,
+          maybeJSON(params.parameters)
         )
         break
       case 'runAction':

--- a/test/specs/Messages.test.ts
+++ b/test/specs/Messages.test.ts
@@ -1214,6 +1214,18 @@ describe(Messages, () => {
       expect(track).toHaveBeenCalledWith("Submit", NaN, undefined, undefined)
     })
 
+    it("calls context.track to track events with parameters", () => {
+      const renderedMessage = createMockMessageRender()
+      const jsonParams = {"input":5}
+      const parameters = encodeURIComponent(JSON.stringify(jsonParams))
+
+      // satisfaction survey
+      messages.processMessageEvent("123", `http://leanplum/track?event=Submit&value=0&parameters=${parameters}`)
+
+      const track = renderedMessage.metadata.context.track
+      expect(track).toHaveBeenCalledWith("Submit", 0, undefined, jsonParams)
+    })
+
     it("tracks impressions on loadFinished events", () => {
       const renderedMessage = createMockMessageRender()
 


### PR DESCRIPTION
Event parameters tracked through rich in-app messages (e.g. satisfaction survey) have not been passing event parameters. This PR resolves this, by correctly passing them to the API. This allows customers to analyze the results of the satisfaction survey IAM.

LP-12057